### PR TITLE
export of methods and define methods for InterfaceQuantity

### DIFF
--- a/examples/Example125_TestFunctions1D.jl
+++ b/examples/Example125_TestFunctions1D.jl
@@ -6,7 +6,7 @@ For a rather comprehensive explanation
 see [225: Terminal flux calculation via test functions, nD](@ref)
 =#
 
-module Example125_TestFunctions1D 
+module Example125_TestFunctions1D
 using Printf
 using VoronoiFVM
 using ExtendableGrids
@@ -16,8 +16,8 @@ using GridVisualize
 function main(;n=100,Plotter=nothing,verbose=false,unknown_storage=:sparse)
     h=1/n
     grid=VoronoiFVM.Grid(collect(0:h:1))
-    
-        
+
+
     eps::Vector{Float64}=[1,1.0e-1]
 
     physics=VoronoiFVM.Physics(
@@ -27,12 +27,12 @@ function main(;n=100,Plotter=nothing,verbose=false,unknown_storage=:sparse)
         f[2]=10*(u[2]-u[1])
     end,
 
-    flux=function(f,u,edge)   
+    flux=function(f,u,edge)
         f[1]=eps[1]*(u[1,1]-u[1,2])
         f[2]=eps[2]*(u[2,1]-u[2,2])
     end,
-    
-    
+
+
     storage=function(f,u,node)
         f[1]=u[1]
         f[2]=u[2]
@@ -46,16 +46,16 @@ function main(;n=100,Plotter=nothing,verbose=false,unknown_storage=:sparse)
     boundary_neumann!(sys,1,1,0.01)
     boundary_dirichlet!(sys,2,2,0.0)
 
-    factory=VoronoiFVM.TestFunctionFactory(sys)
+    factory=TestFunctionFactory(sys)
     tf1=testfunction(factory,[2],[1])
     tf2=testfunction(factory,[1],[2])
-    
-    
+
+
     U=unknowns(sys)
     inival=unknowns(sys)
     inival[2,:].=0.1
     inival[1,:].=0.1
-    
+
     control=VoronoiFVM.NewtonControl()
     control.verbose=verbose
     control.damp_initial=0.1

--- a/examples/Example150_Impedance1D.jl
+++ b/examples/Example150_Impedance1D.jl
@@ -39,7 +39,7 @@ function main(;nref=0,Plotter=nothing,verbose=false, unknown_storage=:sparse,
     # Create array which is refined close to 0
     h0=0.005/2.0^nref
     h1=0.1/2.0^nref
-    
+
     X=VoronoiFVM.geomspace(0,L,h0,h1)
 
     # Create discretitzation grid
@@ -65,7 +65,7 @@ function main(;nref=0,Plotter=nothing,verbose=false, unknown_storage=:sparse,
     excited_bcval=1.0
     excited_spec=1
     meas_bc=2
-    
+
     # Create physics struct
     physics=VoronoiFVM.Physics(data=data,
                                flux=flux,
@@ -80,8 +80,8 @@ function main(;nref=0,Plotter=nothing,verbose=false, unknown_storage=:sparse,
     # Create test functions for current measurement
 
 
-    
-    factory=VoronoiFVM.TestFunctionFactory(sys)
+
+    factory=TestFunctionFactory(sys)
     measurement_testfunction=testfunction(factory,[excited_bc],[meas_bc])
 
     boundary_dirichlet!(sys,excited_spec,excited_bc,excited_bcval)

--- a/examples/Example151_Impedance1D.jl
+++ b/examples/Example151_Impedance1D.jl
@@ -43,7 +43,7 @@ function main(;nref=0,Plotter=nothing,verbose=false, unknown_storage=:sparse,
     # Create array which is refined close to 0
     h0=0.005/2.0^nref
     h1=0.1/2.0^nref
-    
+
     X=VoronoiFVM.geomspace(0,L,h0,h1)
 
     # Create discretitzation grid
@@ -65,7 +65,7 @@ function main(;nref=0,Plotter=nothing,verbose=false, unknown_storage=:sparse,
         f[1]=data.R*u[1]
     end
 
-    
+
     excited_bc=1
     excited_bcval=1.0
     excited_spec=1
@@ -76,7 +76,7 @@ function main(;nref=0,Plotter=nothing,verbose=false, unknown_storage=:sparse,
         boundary_dirichlet!(f,u,node,region=excited_bc,value=p[1])
         boundary_dirichlet!(f,u,node,region=meas_bc,value=0.0)
     end
-    
+
 
     # Create discrete system and enabe species
     sys=VoronoiFVM.System(grid,unknown_storage=unknown_storage,
@@ -89,10 +89,10 @@ function main(;nref=0,Plotter=nothing,verbose=false, unknown_storage=:sparse,
                           species=1
                           )
 
- 
+
     # Create test functions for current measurement
-    
-    factory=VoronoiFVM.TestFunctionFactory(sys)
+
+    factory=TestFunctionFactory(sys)
     measurement_testfunction=testfunction(factory,[excited_bc],[meas_bc])
 
     steadystate=solve(sys,inival=0.0,params=[1.0])

--- a/examples/Example225_TestFunctions2D.jl
+++ b/examples/Example225_TestFunctions2D.jl
@@ -39,13 +39,13 @@ For the stationary problem, we have the following flux balances derived from the
 \end{aligned}
 ```
 
-The volume integrals can be approximated based on the finite volume subdivision 
+The volume integrals can be approximated based on the finite volume subdivision
 $\Omega=\cup_{i\in \mathcal N} \omega_i$:
 
 ```math
 \begin{aligned}
 \int_\Omega r(u_1,u_2) d\omega &\approx \sum_{i\in \mathcal N} |\omega_i| r(u_{1,i},u_{2,i})\\
-\int_\Omega f d\omega &\approx \sum_{i\in \mathcal N} |\omega_i| f_i  
+\int_\Omega f d\omega &\approx \sum_{i\in \mathcal N} |\omega_i| f_i
 \end{aligned}
 ```
 
@@ -53,7 +53,7 @@ But what about  the boundary integral ?  Here, we use a  trick to cast
 the surface  integral to the  integral to  a volume integral  with the
 help of a test function:
 
-Let $T(x)$ be the solution of the Laplace problem $-\nabla^2 T =0$ in $\Omega$ and the boundary conditions 
+Let $T(x)$ be the solution of the Laplace problem $-\nabla^2 T =0$ in $\Omega$ and the boundary conditions
 
 ```math
 \begin{aligned}
@@ -69,7 +69,7 @@ Write ``\vec j=-\nabla u``. and assume $\nabla\cdot \vec j + r =f$.
 ```math
 \begin{aligned}
 \int_{\Gamma_2} \vec j \cdot \vec n ds&=\int_{\Gamma_2} T\vec j \cdot \vec n ds \quad \text{due to}\; T=1\; \text{on}\; \Gamma_2\\
- &=\int_{\partial\Omega}  T\vec j \cdot \vec n ds\quad \text{due to}\; T=0\; \text{on}\; \Gamma_4, \quad\vec j\cdot \vec n=0\; \text{on}\; \Gamma_1, \Gamma_3\\ 
+ &=\int_{\partial\Omega}  T\vec j \cdot \vec n ds\quad \text{due to}\; T=0\; \text{on}\; \Gamma_4, \quad\vec j\cdot \vec n=0\; \text{on}\; \Gamma_1, \Gamma_3\\
 &= \int_\Omega \nabla \cdot (T \vec j) d\omega \quad \text{(Gauss)}\\
 &= \int_\Omega \nabla T \cdot \vec j d\omega + \int_\Omega T \nabla\cdot j d\omega\\
 &=  \int_\Omega \nabla T \cdot \vec j d\omega + \int_\Omega T(f-r)dω\\
@@ -80,7 +80,7 @@ and we approximate
 
 ```math
 \begin{aligned}
-\int_\Omega \nabla T \cdot \vec j d\omega \approx \sum_{k,l} 
+\int_\Omega \nabla T \cdot \vec j d\omega \approx \sum_{k,l}
 \frac{|\omega_k\cap\omega_l|}{h_{k,l}}g(u_k, u_l) (T_k-T_l)
 \end{aligned}
 ```
@@ -131,55 +131,55 @@ function main(;n=10,Plotter=nothing,verbose=false, unknown_storage=:sparse,dim=2
         Γ_where_T_equal_1=[2]
         Γ_where_T_equal_0=[4]
     end
-    
+
     function storage(f,u,node)
         f.=u
     end
-    
+
     function flux(f,u,edge)
 	f[1]=u[1,1]-u[1,2]
 	f[2]=u[2,1]-u[2,2]
     end
-    
+
     r(u1,u2)= u1-0.1*u2
-    
+
     function reaction(f,u,node)
 	f[1]= r(u[1],u[2])
 	f[2]=-r(u[1],u[2])
     end
-    
-    
+
+
     function source(f,node)
 	f[1]=1.0
     end
-    
+
     physics=VoronoiFVM.Physics(flux=flux,
 	                       storage=storage,
 	                       reaction=reaction,
 	                       source=source)
-    
+
     system=VoronoiFVM.System(grid,physics)
 
     enable_species!(system,1,[1])
     enable_species!(system,2,[1])
     boundary_dirichlet!(system,2,2,0.0);
-    
-    
+
+
     inival=unknowns(system,inival=0.0)
-    
+
     sol=solve(inival,system)
-    
+
     vis=GridVisualizer(Plotter=Plotter,layout=(1,2),resolution=(600,300),fignumber=1)
     scalarplot!(vis[1,1],grid,sol[1,:],flimits=(0,1.5),title="u_1")
     scalarplot!(vis[1,2],grid,sol[2,:],flimits=(0,1.5),title="u_2",show=true)
-    
+
     """
         The `integrate` method of `VoronoiFVM`  provides a possibility to calculate
-        the volume integral of a function of a solution as described above. 
-        It returns a `num_specie` x `num_regions` matrix of the integrals 
+        the volume integral of a function of a solution as described above.
+        It returns a `num_specie` x `num_regions` matrix of the integrals
         of the function of the unknowns over the different subdomains (here, we have only one):
     """
-    
+
     """
         Amount of u_1 and u_2 in the domain aka integral over identity storage function:
     """
@@ -189,49 +189,49 @@ function main(;n=10,Plotter=nothing,verbose=false, unknown_storage=:sparse,dim=2
     Amount of species created by source term per unit time:
     """
     F=integrate(system,(f,u,node)->source(f,node),sol)
-    
+
     """
     Amount of  reaction per unit time:
     """
     R=integrate(system,reaction,sol)
-    
 
-    tf=VoronoiFVM.TestFunctionFactory(system)
+
+    tf=TestFunctionFactory(system)
     T=testfunction(tf,Γ_where_T_equal_0,Γ_where_T_equal_1)
-    
+
     I=integrate(system,T,sol)
-    
-    
+
+
     t0=0.0
-    
+
     control=fixed_timesteps!(VoronoiFVM.NewtonControl(),dt)
 
     tsol=solve(inival,system,[t0,tend],control=control)
 
-    
+
     vis1=GridVisualizer(Plotter=Plotter,layout=(1,2),resolution=(600,300),fignumber=4)
-    
+
     for i=1:length(tsol)
         sol=tsol[i]
         scalarplot!(vis1[1,1],grid,sol[1,:],flimits=(0,1.5),clear=true)
         scalarplot!(vis1[1,2],grid,sol[2,:],flimits=(0,1.5),show=true)
     end
-    
+
     outflow_rate=Float64[]
     for i=2:length(tsol)
 	ofr=integrate(system,T,tsol[i],tsol[i-1],tsol.t[i]-tsol.t[i-1])
   	push!(outflow_rate,ofr[2])
     end
-    
+
     vis2=GridVisualizer(Plotter=Plotter,layout=(1,1),resolution=(600,300),fignumber=2)
     scalarplot!(vis2[1,1],[0,tend],-[I[2],I[2]],label="stationary",clear=true)
     scalarplot!(vis2[1,1],tsol.t[2:end],-outflow_rate,label="transient",show=true)
-    
+
     all_outflow=0.0
     for i=1:length(tsol)-1
 	all_outflow-=outflow_rate[i]*(tsol.t[i+1]-tsol.t[i])
     end
-    
+
     Uend=integrate(system,storage,tsol[end])
     isapprox(F[1], R[1],rtol=1.0e-12)  ? true : return false
     isapprox(I[1], 0.0, atol=1.0e-12)  ? true : return false

--- a/examples/Example226_BoundaryIntegral.jl
+++ b/examples/Example226_BoundaryIntegral.jl
@@ -26,34 +26,34 @@ function main(;n=10,Plotter=nothing,verbose=false, unknown_storage=:sparse,dim=2
         Γ_where_T_equal_1=[2]
         Γ_where_T_equal_0=[4]
     end
-    
+
     function storage(f,u,node)
         f.=u
     end
-    
+
     function flux(f,u,edge)
 	f[1]=u[1,1]-u[1,2]
     end
-    
-    
+
+
     function breaction(f,u,node)
         if node.region==Γ_where_T_equal_1[1]
             f[1]= u[1]^2
         end
     end
-    
+
     physics=VoronoiFVM.Physics(flux=flux,
 	                       storage=storage,
 	                       breaction=breaction)
-    
+
     system=VoronoiFVM.System(grid,physics)
     enable_species!(system,1,[1])
     boundary_dirichlet!(system,1,Γ_where_T_equal_0[1],1.0);
     inival=unknowns(system,inival=0.0)
-    
+
     U=solve(inival,system)
 
-    tf=VoronoiFVM.TestFunctionFactory(system)
+    tf=TestFunctionFactory(system)
     T=testfunction(tf,Γ_where_T_equal_0,Γ_where_T_equal_1)
 
     scalarplot(grid,U[1,:],Plotter=Plotter,zplane=0.50001)

--- a/examples/Example420_DiscontinuousQuantities.jl
+++ b/examples/Example420_DiscontinuousQuantities.jl
@@ -24,7 +24,7 @@ function main(;N=5, Plotter=nothing,unknown_storage=:sparse)
     grid2=simplexgrid(xcoord)
     for i=1:N
         cellmask!(grid2,[i-1],[i],i)
-    end	
+    end
     for i=1:N-1
         bfacemask!(grid2,[i],[i],i+2)
     end
@@ -35,7 +35,7 @@ function main(;N=5, Plotter=nothing,unknown_storage=:sparse)
         params[2,i]=10*i
     end
 
-    
+
     system=VoronoiFVM.System(grid2,unknown_storage=unknown_storage)
 
     ## First, we introduce a continuous quantity which we name "cspec". Note that the "species number" can be assigned automatically if not given explicitely.
@@ -58,7 +58,7 @@ function main(;N=5, Plotter=nothing,unknown_storage=:sparse)
         @assert params2[i] == 2
     end
 
-    
+
 
     # check 2D array acces with quantities
     for i=1:num_cellregions(grid2)
@@ -80,7 +80,7 @@ function main(;N=5, Plotter=nothing,unknown_storage=:sparse)
 
 
 
-    
+
     ##For both quantities, we define simple diffusion fluxes:
 
     function flux(f,u,edge)
@@ -94,7 +94,7 @@ function main(;N=5, Plotter=nothing,unknown_storage=:sparse)
 
     function breaction(f,u,bnode)
 
-        # left outer boundary value for dspec 
+        # left outer boundary value for dspec
         if bnode.region == 1
             f[dspec] = u[dspec] + 0.5
         end
@@ -107,14 +107,14 @@ function main(;N=5, Plotter=nothing,unknown_storage=:sparse)
             f[cspec]=-q1*u[cspec]
         end
     end
-    
+
 
     physics!(system,VoronoiFVM.Physics(
         flux=flux,
         breaction=breaction
     ))
-    
-    
+
+
     ## Set boundary conditions
     boundary_dirichlet!(system,dspec,2,0.1)
     boundary_dirichlet!(system,cspec,1,0.1)
@@ -124,10 +124,10 @@ function main(;N=5, Plotter=nothing,unknown_storage=:sparse)
 
     U=solve(unknowns(system,inival=0),system)
 
-    dvws=VoronoiFVM.views(U,dspec,subgrids,system)
-    cvws=VoronoiFVM.views(U,cspec,subgrids,system)
+    dvws=views(U,dspec,subgrids,system)
+    cvws=views(U,cspec,subgrids,system)
     vis=GridVisualizer(resolution=(600,300),Plotter=Plotter)
-    for i=1:length(dvws)
+    for i in eachindex(dvws)
         scalarplot!(vis,subgrids[i],dvws[i],flimits=(-0.5,1.5),clear=false,color=:red)
         scalarplot!(vis,subgrids[i],cvws[i],flimits=(-0.5,1.5),clear=false,color=:green)
     end

--- a/examples/Example422_InterfaceQuantities.jl
+++ b/examples/Example422_InterfaceQuantities.jl
@@ -61,8 +61,8 @@ function main(;n=5, Plotter = nothing, tend = 20.0, unknown_storage=:sparse,
     sys    = VoronoiFVM.System(grid, unknown_storage = unknown_storage)
     iphin  = DiscontinuousQuantity(sys, 1:numberOfRegions, id = 1)
     iphip  = DiscontinuousQuantity(sys, 1:numberOfRegions, id = 2)
-    iphinb = InterfaceQuantity(sys,     bjunction,         id = 3)
-    iphipb = InterfaceQuantity(sys,     bjunction,         id = 4)
+    iphinb = InterfaceQuantity(sys,     [bjunction],       id = 3)
+    iphipb = InterfaceQuantity(sys,     [bjunction],       id = 4)
     ipsi   = ContinuousQuantity(sys,    1:numberOfRegions, id = 5)
 
     NA  = [10.0, 0.0];  ND = [0.0, 10.0]

--- a/examples/Example422_InterfaceQuantities.jl
+++ b/examples/Example422_InterfaceQuantities.jl
@@ -43,27 +43,27 @@ function main(;n=5, Plotter = nothing, tend = 20.0, unknown_storage=:sparse,
 
     # specify inner regions
     cellmask!(grid, [0.0], [h1], region1)
-    cellmask!(grid, [h1],  [h1 + h2], region2) 
- 
+    cellmask!(grid, [h1],  [h1 + h2], region2)
+
     # specifiy outer regions
-    bfacemask!(grid, [0.0],     [0.0],     bregion1) 
-    bfacemask!(grid, [h_total], [h_total], bregion2) 
+    bfacemask!(grid, [0.0],     [0.0],     bregion1)
+    bfacemask!(grid, [h_total], [h_total], bregion2)
 
     # inner interfaces
-    bfacemask!(grid, [h1], [h1], bjunction) 
+    bfacemask!(grid, [h1], [h1], bjunction)
 
     #gridplot(grid, Plotter = nothing, legend=:rt)
-    
+
     ################################################################################
     #########  system
     ################################################################################
 
-    sys     = VoronoiFVM.System(grid, unknown_storage = unknown_storage)
-    iphin   = DiscontinuousQuantity(sys, 1:numberOfRegions, id = 1)
-    iphip   = DiscontinuousQuantity(sys, 1:numberOfRegions, id = 2)
-    iphin_b = InterfaceQuantity(sys,     bjunction,         id = 3)
-    iphip_b = InterfaceQuantity(sys,     bjunction,         id = 4)
-    ipsi    = ContinuousQuantity(sys,    1:numberOfRegions, id = 5)
+    sys    = VoronoiFVM.System(grid, unknown_storage = unknown_storage)
+    iphin  = DiscontinuousQuantity(sys, 1:numberOfRegions, id = 1)
+    iphip  = DiscontinuousQuantity(sys, 1:numberOfRegions, id = 2)
+    iphinb = InterfaceQuantity(sys,     bjunction,         id = 3)
+    iphipb = InterfaceQuantity(sys,     bjunction,         id = 4)
+    ipsi   = ContinuousQuantity(sys,    1:numberOfRegions, id = 5)
 
     NA  = [10.0, 0.0];  ND = [0.0, 10.0]
 
@@ -74,7 +74,7 @@ function main(;n=5, Plotter = nothing, tend = 20.0, unknown_storage=:sparse,
 
         f[iphin] = - exp(etan)
         f[iphip] =   exp(etap)
-    
+
         f[ipsi]  =  0.0
 
     end
@@ -96,7 +96,7 @@ function main(;n=5, Plotter = nothing, tend = 20.0, unknown_storage=:sparse,
     function flux!(f, u, node)
 
         f[ipsi] =  - (u[ipsi, 2] - u[ipsi, 1])
- 
+
         ########################
         bp, bm = fbernoulli_pm(-  (u[ipsi, 2] - u[ipsi, 1]) )
 
@@ -118,8 +118,8 @@ function main(;n=5, Plotter = nothing, tend = 20.0, unknown_storage=:sparse,
             pleft    = exp(  ( (u[iphip, 1] - u[ipsi]) ))
 
             # interface species
-            n_interf = exp(- ( (u[iphin_b]  - u[ipsi]) )) 
-            p_interf = exp(  ( (u[iphip_b]  - u[ipsi]) ))
+            n_interf = exp(- ( (u[iphinb]   - u[ipsi]) ))
+            p_interf = exp(  ( (u[iphipb]   - u[ipsi]) ))
 
             # right values
             nright   = exp(- ( (u[iphin, 2] - u[ipsi]) ))
@@ -132,15 +132,15 @@ function main(;n=5, Plotter = nothing, tend = 20.0, unknown_storage=:sparse,
 
             # left and right reaction for p
             f[iphip, 1] = reactionP * (pleft  - p_interf)
-            f[iphip, 2] = reactionP * (pright - p_interf) 
+            f[iphip, 2] = reactionP * (pright - p_interf)
 
             # interface species reaction
-            f[iphin_b] =  - (f[iphin, 1] + f[iphin, 2]) 
-            f[iphip_b] =  - (f[iphip, 1] + f[iphip, 2]) 
+            f[iphinb]   =  - (f[iphin, 1] + f[iphin, 2])
+            f[iphipb]   =  - (f[iphip, 1] + f[iphip, 2])
 
         end
 
-        
+
     end
 
     function bstorage!(f, u, bnode)
@@ -149,12 +149,12 @@ function main(;n=5, Plotter = nothing, tend = 20.0, unknown_storage=:sparse,
 
         if bnode.region == bjunction
 
-            etan = - ( (u[iphin_b] - u[ipsi]) )
-            etap =   ( (u[iphip_b] - u[ipsi]) )
-    
-            f[iphin_b] = - exp(etan)
-            f[iphip_b] =   exp(etap)
-        
+            etan = - ( (u[iphinb] - u[ipsi]) )
+            etap =   ( (u[iphipb] - u[ipsi]) )
+
+            f[iphinb] = - exp(etan)
+            f[iphipb] =   exp(etap)
+
         end
 
     end
@@ -188,7 +188,7 @@ function main(;n=5, Plotter = nothing, tend = 20.0, unknown_storage=:sparse,
     tvalues = range(t0, stop = tend, length = ntsteps)
 
     for istep = 2:ntsteps
-    
+
         t   = tvalues[istep]       # Actual time
         Δt  = t - tvalues[istep-1] # Time step size
 
@@ -217,7 +217,7 @@ function main(;n=5, Plotter = nothing, tend = 20.0, unknown_storage=:sparse,
         inival .= sol
 
         ## get current
-        factory = VoronoiFVM.TestFunctionFactory(sys)
+        factory = TestFunctionFactory(sys)
         tf      = testfunction(factory, [1], [2])
         I       = integrate(sys, tf, sol)
 
@@ -229,28 +229,28 @@ function main(;n=5, Plotter = nothing, tend = 20.0, unknown_storage=:sparse,
         push!(Idspec, val)
 
     end # bias loop
-    
+
     ################################################################################
     #########  Plotting
     ################################################################################
 
-    vis = GridVisualizer(Plotter = nothing, layout=(2,1))
+    vis = GridVisualizer(Plotter = Plotter, layout=(2,1))
 
-    subgrids = VoronoiFVM.subgrids(iphin, sys)
-    phin_sol = VoronoiFVM.views(sol, iphin, subgrids, sys)
-    phip_sol = VoronoiFVM.views(sol, iphip, subgrids, sys)
-    psi_sol  = VoronoiFVM.views(sol, ipsi,  subgrids, sys)
+    subgridBulk = subgrids(iphin, sys)
+    phin_sol    = views(sol, iphin, subgridBulk, sys)
+    phip_sol    = views(sol, iphip, subgridBulk, sys)
+    psi_sol     = views(sol, ipsi,  subgridBulk, sys)
 
-    for i = 1:length(phin_sol)
-        scalarplot!(vis[1, 1], subgrids[i], phin_sol[i], clear = false, color=:green)
-        scalarplot!(vis[1, 1], subgrids[i], phip_sol[i], clear = false, color=:red)
-        scalarplot!(vis[1, 1], subgrids[i], psi_sol[i],  clear = false, color=:blue)
+    for i in eachindex(phin_sol)
+        scalarplot!(vis[1, 1], subgridBulk[i], phin_sol[i], clear = false, color=:green)
+        scalarplot!(vis[1, 1], subgridBulk[i], phip_sol[i], clear = false, color=:red)
+        scalarplot!(vis[1, 1], subgridBulk[i], psi_sol[i],  clear = false, color=:blue)
     end
 
     scalarplot!(vis[2, 1], biasval, Idspec, clear = false, color=:red)
 
-    bgrid     = subgrid(grid, [bjunction], boundary = true)
-    sol_bound = view(sol[iphin_b.ispec, :], bgrid)
+    bgrid     = subgrids(iphinb, sys)
+    sol_bound = views(sol, iphinb, bgrid, sys)
 
     return sol_bound[1]
 

--- a/src/VoronoiFVM.jl
+++ b/src/VoronoiFVM.jl
@@ -90,11 +90,13 @@ export nodeflux
 include("vfvm_testfunctions.jl")
 export integrate
 export testfunction
+export TestFunctionFactory
 
 include("vfvm_quantities.jl")
 export ContinuousQuantity
 export DiscontinuousQuantity
 export InterfaceQuantity
+export subgrids,views
 
 
 include("vfvm_impedance.jl")

--- a/src/vfvm_quantities.jl
+++ b/src/vfvm_quantities.jl
@@ -72,9 +72,9 @@ struct InterfaceQuantity{Ti}<: AbstractQuantity{Ti}
     ispec::Ti
 
     """
-    boundary region, where interface quantity is defined
+    boundary regions, where interface quantity is defined
     """
-    breg::Ti
+    bregspec::Vector{Ti}
 
     """
     Quantity identifier allowing to use the quantity as index
@@ -87,26 +87,26 @@ end
      InterfaceQuantity(system,regions; ispec=0, id=0)
 
 
-Add interface quantity to the boundary region given in `breg`.
+Add interface quantity to the boundary regions given in `breg`.
 
 Unless specified in `ispec`, the species number is generated
 automtically.
 
 Unless specified by `id`, the quantity ID is generated automatically.
 """
-function InterfaceQuantity(sys::AbstractSystem{Tv,Ti,Tm},breg;ispec=0,id=0) where {Tv,Ti,Tm}
+function InterfaceQuantity(sys::AbstractSystem{Tv,Ti,Tm},bregions::AbstractVector ;ispec=0,id=0) where {Tv,Ti,Tm}
     if ispec==0
         nspec=num_species(sys)
         nspec=nspec+1
     else
         nspec=ispec
     end
-    enable_boundary_species!(sys,nspec,[breg])
+    enable_boundary_species!(sys,nspec, bregions)
     sys.num_quantities+=1
     if id==0
         id=sys.num_quantities
     end
-    InterfaceQuantity{Ti}(nspec,breg,id)
+    InterfaceQuantity{Ti}(nspec,bregions,id)
 end
 
 ###########################################################
@@ -142,7 +142,7 @@ are generated automatically.
 
 Unless specified by `id`, the quantity ID is generated automatically.
 """
-function DiscontinuousQuantity(sys::AbstractSystem{Tv,Ti,Tm},regions; regionspec=nothing, id=0) where {Tv,Ti,Tm}
+function DiscontinuousQuantity(sys::AbstractSystem{Tv,Ti,Tm},regions::AbstractVector; regionspec=nothing, id=0) where {Tv,Ti,Tm}
     rspec=zeros(Ti,num_cellregions(sys.grid))
     if regionspec==nothing
         nspec=num_species(sys)
@@ -201,7 +201,7 @@ Return the subgrid where interface quantity is defined.
 function subgrids(quantity::InterfaceQuantity, sys)
     grid=sys.grid
     bgrid=Vector{ExtendableGrid}(undef,0)
-    bgrid=subgrid(grid,[quantity.breg], boundary = true)
+    bgrid=subgrid(grid, quantity.bregspec, boundary = true)
 end
 
 


### PR DESCRIPTION
Note that the tests are not running not because of these changes but due to changes within DifferentialEquations.jl and OrdinaryDiffEq.jl. If excluding Example108 from the tests, everything works fine.

I tried to pin DifferentialEquations.jl and OrdinaryDiffEq.jl to the versions, where the latest version of VoronoiFVM.jl passed the tests, but I was not successful ...