### PR TITLE
Clarified implementation of breaction

### DIFF
--- a/examples/Example121_PoissonPointCharge1D.jl
+++ b/examples/Example121_PoissonPointCharge1D.jl
@@ -4,11 +4,15 @@
 
 Solve a Poisson equation
 ```math
-- \Delta u = 0
+- \Delta u = 0,
 ```
 
-in $\Omega=(-1,1)$
-with a point charge $Q$ at $x=0$. 
+in $\Omega=(-1,0)\cup (0,1)$ and
+```math
+u'_+(0) - u'_-(0) + Q = 0
+```
+at $x=0$. Unknown ``u`` corresponds to the electrostatic potential of a point charge $Q$ located at ``x=0``.
+The subscripts ``+`` and ``-`` denote the one-sided limits ``u'_+(0):=\lim_{x\to 0, x > 0} u(x)`` and ``u'_-(0):=\lim_{x\to 0, x < 0} u(x)``, respectively.
 =#
 
 module Example121_PoissonPointCharge1D
@@ -48,7 +52,7 @@ function main(;nref=0,Plotter=nothing, verbose=false, unknown_storage=:sparse, b
     end
 
     ## Define boundary reaction defining charge
-    ## Note that the term  is written on  the left hand side, therefore the - sign
+    ## Note that the breaction is implemented as a right hand side, therefore the - sign
     function breaction!(f,u,node)
         if node.region==3
             f[1]=-Q


### PR DESCRIPTION
Let us assume a charge density $Q$ confined to a surface (*surface charge density*) between domains $\Omega_-$ and $\Omega_+$. The surface charge density causes a discontinuity of the normal components of the displacement field,
```math
(-\varepsilon \nabla\phi_{+})\cdot\nu_{+} 
+
(-\varepsilon \nabla\phi_{-})\cdot\nu_{-}
=
-Q
```
across the surface. Here $\nu_{+,-}$ denote the outer normals to $\Omega_{+,-}$.  This is consistent with e.g. [Dreyer et al, Eqn 27b](https://www.mdpi.com/1099-4300/20/12/939) (beware, $\nu$ therein denotes the outer normal of $\Omega_-$).

For $\varepsilon=1$ in 1D, the equation simplifies to
```math
\phi_{+}'
-
\phi_{-}'
+
Q
=
0
```

See the solutions of the `Example121` for homogeneous Dirichlet BCs for $Q>0$

![Q>0](https://user-images.githubusercontent.com/14977619/203072430-9e113cb8-7349-4680-9645-a1d6e5626f10.svg)
and $Q<0$.
![Q<0](https://user-images.githubusercontent.com/14977619/203072441-54e74b35-aa76-4970-bc18-d3b47ab9c5a7.svg)
The plots are consistent with the 1D equation above. However in `breaction`, the surface charge enters with ``-`` sign as ``-Q``. 