### PR TITLE
Adjust edgevelocities and bfacevelocities calculation

### DIFF
--- a/src/VoronoiFVM.jl
+++ b/src/VoronoiFVM.jl
@@ -84,6 +84,7 @@ export meas, project
 export unknown_indices
 export edgevelocities, bfacevelocities, bfacenodefactors
 export time, region, embedparam, parameters
+export calc_divergences
 
 include("vfvm_solvercontrol.jl")
 export fixed_timesteps!, NewtonControl, SolverControl


### PR DESCRIPTION
@chmerdon and I have been working on convection-diffusion problems in cylindrical coordinates and we have noticed that seemingly inaccurate solutions are computed for a stagnation flow example with a constant exact solution.

So we adjusted the `edgevelocities` and `bfacevelocities` functions to accomodate various coordinate systems and included a function to calculate the discrete divergences per grid node (i.e. Voronoi cell).

This did fix our issue on a structured grid (but *not* on an unstructured grid).