### PR TITLE
bugfix for bfacefactors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VoronoiFVM"
 uuid = "82b139dc-5afc-11e9-35da-9b9bdfd336f3"
 authors = ["Jürgen Fuhrmann <juergen.fuhrmann@wias-berlin.de>", "Dilara Abdel", "Jan Weidner", "Alexander Seiler", "Patricio Farrell", "Matthias Liero"]
-version = "1.17.0"
+version = "1.17.1"
 
 [deps]
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"

--- a/examples/Example311_HeatEquation_BoundaryDiffusion.jl
+++ b/examples/Example311_HeatEquation_BoundaryDiffusion.jl
@@ -13,7 +13,7 @@ using ExtendableGrids
 """
   We solve the following system
 
-      ∂_tu - εΔu = 0            in [0,T] × Ω
+      ∂_tu - εΔu = 0            in [0,T] × Ω>
            ε∇u⋅ν = k(u-v)       on [0,T] × Γ_1
            ε∇u⋅ν = 0            on [0,T] × (∂Ω ∖ Γ_1)
   ∂_tv -ε_ΓΔ_Γ v = f(x) +k(u-v) on [0,T] × Γ_1
@@ -106,8 +106,9 @@ end
 using Test
 function runtests()
     testval = 1509.8109057757858
-    @test isapprox(main(; assembly = :edgewise), testval; rtol = 1.0e-12) &&
-          isapprox(main(; assembly = :cellwise), testval; rtol = 1.0e-12)
+    testval = 1508.582565216869
+    @test isapprox(main(; assembly = :edgewise), testval; rtol = 1.0e-12) 
+    @test isapprox(main(; assembly = :cellwise), testval; rtol = 1.0e-12)
 end
 
 end

--- a/src/vfvm_formfactors.jl
+++ b/src/vfvm_formfactors.jl
@@ -314,15 +314,19 @@ function bfacefactors!(T::Type{Triangle2D}, ::Type{<:Cartesian3D}, coord, bfacen
 
     d = 1.0 / (8 * vol)
 
-    # Knoten-Flaechenanteile (ohne Abschneiden)
-    npar[1] = (epar[3] + epar[2]) * d * 0.25
-    npar[2] = (epar[1] + epar[3]) * d * 0.25
-    npar[3] = (epar[2] + epar[1]) * d * 0.25
 
-    # Kantengewichte 
+    # Knoten-Flaechenanteile (ohne Abschneiden)
+    npar .= 0.0
+    for i = 1:3
+        npar[en[1, i]] += epar[i] * d * 0.25
+        npar[en[2, i]] += epar[i] * d * 0.25
+    end
+
+    # Kantengewichte
     epar[1] = epar[1] * d / dd[1]
     epar[2] = epar[2] * d / dd[2]
     epar[3] = epar[3] * d / dd[3]
+    
     nothing
 end
 

--- a/test/test_formfactors.jl
+++ b/test/test_formfactors.jl
@@ -1,0 +1,28 @@
+module test_formfactors
+using Test
+using ExtendableGrids
+using VoronoiFVM: cellfactors!, bfacefactors!
+
+randpoint=rand(-10:0.01:10,2)
+function ttri(;ntest=100)
+    cellnodes=[1 2 3;]'
+    icell=1
+    epar2d=zeros(3)
+    npar2d=zeros(3)           
+    epar3d=zeros(3)
+    npar3d=zeros(3)           
+    for i=1:100
+        coord2d=rand(-10:0.01:10,2,3)
+        coord3d=vcat(coord2d,[0.0,0,0]')
+
+        cellfactors!(Triangle2D,Cartesian2D,coord2d,cellnodes,1,npar2d,epar2d)
+        bfacefactors!(Triangle2D,Cartesian3D,coord3d,cellnodes,1,npar3d,epar3d)
+
+        @test npar3d ≈ npar2d
+        @test epar3d ≈ epar2d
+    end
+end
+
+
+end
+


### PR DESCRIPTION
Nodefactors weren't created in the right sequence. Robin  and Neuamann boundary conditions in 3D were affected.
