### PR TITLE
export upgrade_grid_cellwise! for accessing nodefactors

### DIFF
--- a/src/VoronoiFVM.jl
+++ b/src/VoronoiFVM.jl
@@ -81,7 +81,7 @@ export coordinates
 
 """
 $(TYPEDEF)
-    
+
 Abstract type for finite volume system structure.
 """
 abstract type AbstractSystem{Tv <: Number, Tc <: Number, Ti <: Integer, Tm <: Integer} end
@@ -104,6 +104,7 @@ export evaluate_residual_and_jacobian
 export edgelength
 export viewK, viewL, data
 export hasoutflownode, isoutflownode, outflownode
+export update_grid_cellwise!
 
 @compat public System, AbstractSystem
 


### PR DESCRIPTION
With upgrade_grid_cellwise! the user can access the nodefactors, which are needed to calculate the integral of a solution $u$.
We have

$$
\int_{\mathbf{\Omega}} u(\mathbf{x})   d\mathbf{x} = \sum_K \int_{\omega_K} u(\mathbf{x})  d\mathbf{x} \approx \sum_K |\omega_K| u(\mathbf{x}_K).
$$

The measure of the control volumes $|\omega_K|$ can be accessed with nodefactors

```julia
update_grid_cellwise!(sys, grid)
nodefac = sys.assembly_data.nodefactors
```

and the integral can be then calculated via

```julia
cellnodes = grid[CellNodes] # nodes per simplex x number of simplices
uInt = 0.0
for icell = 1:size(cellnodes, 2) # number of simplices
    for inode = 1:size(cellnodes, 1) # each node in simplex

        inodeIndexGrid = cellnodes[inode, icell]
        uInt = uInt + nodefac[inode, icell] * u[inodeIndexGrid] # u as the PDE solution

    end
end
```