### PR TITLE
Deprecate VoronoiFVM.Physics callbacks without `data` argument

### DIFF
--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -1,9 +1,9 @@
 # Changes
+## upcoming release
+- [`VoronoiFVM.Physics`](@ref) callbacks (`flux`, `storage`, etc.) without `data` argument are now deprecated
+
 ## v1.24.0 August 20, 2024 
 - Bernoulli function using expm1 (thanks @tcaduser !)
-
-## v1.23.0 August 2, 2024 
-- Add `integrate(sys,solution)` method
 
 ## v1.23.0 August 2, 2024 
 - Add `integrate(sys,solution)` method

--- a/examples/Example001_Solvers.jl
+++ b/examples/Example001_Solvers.jl
@@ -28,25 +28,25 @@ function main(; n = 10, Plotter = nothing, assembly = :edgwwise, kwargs...)
 
     eps = 1.0e-2
 
-    function reaction(f, u, node)
+    function reaction(f, u, node, data)
         f[1] = u[1]^2
     end
 
-    function flux(f, u, edge)
+    function flux(f, u, edge, data)
         f[1] = eps * (u[1, 1]^2 - u[1, 2]^2)
     end
 
-    function source(f, node)
+    function source(f, node, data)
         x1 = node[1] - 0.5
         x2 = node[2] - 0.5
         f[1] = exp(-20.0 * (x1^2 + x2^2))
     end
 
-    function storage(f, u, node)
+    function storage(f, u, node, data)
         f[1] = u[1]
     end
 
-    function bcondition(f, u, node)
+    function bcondition(f, u, node, data)
         boundary_dirichlet!(f,
                             u,
                             node;

--- a/examples/Example002_EdgeReaction.jl
+++ b/examples/Example002_EdgeReaction.jl
@@ -46,18 +46,18 @@ function main(; nref = 0, dim = 2, Plotter = nothing, verbose = "and", case = :c
         i1 = 6
     end
 
-    function storage!(y, u, node)
+    function storage!(y, u, node, data)
         y[1] = u[1]
     end
 
-    function flux!(y, u, edge)
+    function flux!(y, u, edge, data)
         y[1] = u[1, 1] - u[1, 2]
     end
 
     # Three ways to give a constant reaction term. As a consequence,
     # these need to yield the same solution.
     # 1: classical node reaction, multiplied  by control volume size
-    function reaction!(y, u, node)
+    function reaction!(y, u, node, data)
         y[1] = -1
     end
 
@@ -76,7 +76,7 @@ function main(; nref = 0, dim = 2, Plotter = nothing, verbose = "and", case = :c
     #
     #  τ=1/h    v= s*h/2d = σ*h^2/2d 
     #                
-    function edgereaction!(y, u, edge)
+    function edgereaction!(y, u, edge, data)
         h = meas(edge)
         y[1] = -1 * h^2 / (2 * dim)
     end
@@ -88,14 +88,14 @@ function main(; nref = 0, dim = 2, Plotter = nothing, verbose = "and", case = :c
     # we had before
     ϕ = grid[Coordinates][1, :]
 
-    function edgereaction2!(y, u, edge)
+    function edgereaction2!(y, u, edge, data)
         ϕK = ϕ[edge.node[1]]
         ϕL = ϕ[edge.node[2]]
         y[1] = -(ϕK - ϕL) * (ϕK - ϕL) / 2
     end
 
     if case == :compare_max
-        function bcondition!(y, u, node)
+        function bcondition!(y, u, node, data)
             boundary_dirichlet!(y, u, node; species = 1, region = 1, value = 0)
             boundary_dirichlet!(y, u, node; species = 1, region = 2, value = 0)
             boundary_dirichlet!(y, u, node; species = 1, region = 3, value = 0)
@@ -130,7 +130,7 @@ function main(; nref = 0, dim = 2, Plotter = nothing, verbose = "and", case = :c
     end
 
     if case == :compare_flux
-        function bcondition2!(y, u, node)
+        function bcondition2!(y, u, node, data)
             boundary_dirichlet!(y, u, node; species = 1, region = i1, value = 0)
         end
 

--- a/examples/Example101_Laplace1D.jl
+++ b/examples/Example101_Laplace1D.jl
@@ -96,13 +96,13 @@ function main()
 
     ## Flux function which describes the flux
     ## between neighboring control volumes
-    function flux!(f, u, edge)
+    function flux!(f, u, edge, data)
         f[1] = u[1, 1] - u[1, 2]
     end
 
-    function bcond!(args...)
-        boundary_dirichlet!(args...; region = 1, value = 0)
-        boundary_dirichlet!(args...; region = 2, value = 1)
+    function bcond!(f, u, node, data)
+        boundary_dirichlet!(f, u, node; region = 1, value = 0)
+        boundary_dirichlet!(f, u, node; region = 2, value = 1)
     end
 
     ## Create a one dimensional discretization grid

--- a/examples/Example105_NonlinearPoisson1D.jl
+++ b/examples/Example105_NonlinearPoisson1D.jl
@@ -38,12 +38,12 @@ function main(; n = 10, Plotter = nothing, verbose = false, unknown_storage = :s
 
     ## Flux function which describes the flux
     ## between neighboring control volumes
-    function flux!(f, u, edge)
+    function flux!(f, u, edge, data)
         f[1] = ϵ * (u[1, 1] - u[1, 2])
     end
 
     ## Source term
-    function source!(f, node)
+    function source!(f, node, data)
         if node[1] <= 0.5
             f[1] = 1
         else
@@ -52,7 +52,7 @@ function main(; n = 10, Plotter = nothing, verbose = false, unknown_storage = :s
     end
 
     ## Reaction term
-    function reaction!(f, u, node)
+    function reaction!(f, u, node, data)
         f[1] = exp(u[1]) - exp(-u[1])
     end
 

--- a/examples/Example106_NonlinearDiffusion1D.jl
+++ b/examples/Example106_NonlinearDiffusion1D.jl
@@ -44,12 +44,12 @@ function main(; n = 20, m = 2, Plotter = nothing, verbose = false,
 
     ## Flux function which describes the flux
     ## between neighboring control volumes
-    function flux!(f, u, edge)
+    function flux!(f, u, edge, data)
         f[1] = u[1, 1]^m - u[1, 2]^m
     end
 
     ## Storage term
-    function storage!(f, u, node)
+    function storage!(f, u, node, data)
         f[1] = u[1]
     end
 

--- a/examples/Example107_NonlinearStorage1D.jl
+++ b/examples/Example107_NonlinearStorage1D.jl
@@ -40,7 +40,7 @@ function main(; n = 20, m = 2.0, Plotter = nothing, verbose = false,
 
     ## Flux function which describes the flux
     ## between neighboring control volumes
-    function flux!(f, u, edge)
+    function flux!(f, u, edge, data)
         f[1] = u[1, 1] - u[1, 2]
     end
 
@@ -49,7 +49,7 @@ function main(; n = 20, m = 2.0, Plotter = nothing, verbose = false,
     ## Storage term
     ## This needs to be regularized as its derivative
     ## at 0 is infinity
-    function storage!(f, u, node)
+    function storage!(f, u, node, data)
         f[1] = (ϵ + u[1])^(1.0 / m)
     end
 

--- a/examples/Example108_OrdinaryDiffEq1D.jl
+++ b/examples/Example108_OrdinaryDiffEq1D.jl
@@ -44,12 +44,12 @@ function main(; n = 20, m = 2, Plotter = nothing, verbose = false,
 
     ## Flux function which describes the flux
     ## between neighboring control volumes
-    function flux!(f, u, edge)
+    function flux!(f, u, edg, data)
         f[1] = u[1, 1]^m - u[1, 2]^m
     end
 
     ## Storage term
-    function storage!(f, u, node)
+    function storage!(f, u, node, data)
         f[1] = u[1]
     end
 

--- a/examples/Example110_ReactionDiffusion1D_TwoSpecies.jl
+++ b/examples/Example110_ReactionDiffusion1D_TwoSpecies.jl
@@ -29,20 +29,20 @@ function main(; n = 100, Plotter = nothing, verbose = false, unknown_storage = :
     eps::Vector{Float64} = [1.0, 1.0]
 
     physics = VoronoiFVM.Physics(
-                                 ; reaction = function (f, u, node)
+                                 ; reaction = function (f, u, node, data)
                                      f[1] = u[1] * u[2]
                                      f[2] = -u[1] * u[2]
                                  end,
-                                 flux = function (f, u, edge)
+                                 flux = function (f, u, edge, data)
                                      nspecies = 2
                                      f[1] = eps[1] * (u[1, 1] - u[1, 2]) *
                                             (0.01 + u[2, 1] + u[2, 2])
                                      f[2] = eps[2] * (u[2, 1] - u[2, 2]) *
                                             (0.01 + u[1, 1] + u[1, 2])
-                                 end, source = function (f, node)
+                                 end, source = function (f, node, data)
                                      f[1] = 1.0e-4 * (0.01 + node[1])
                                      f[2] = 1.0e-4 * (0.01 + 1.0 - node[1])
-                                 end, storage = function (f, u, node)
+                                 end, storage = function (f, u, node, data)
                                      f[1] = u[1]
                                      f[2] = u[2]
                                  end)

--- a/examples/Example115_HeterogeneousCatalysis1D.jl
+++ b/examples/Example115_HeterogeneousCatalysis1D.jl
@@ -77,19 +77,19 @@ function main(; n = 10, Plotter = nothing, verbose = false, tend = 1,
     ## Diffusion flux for species A and B
     D_A = 1.0
     D_B = 1.0e-2
-    function flux!(f, u, edge)
+    function flux!(f, u, edge, data)
         f[iA] = D_A * (u[iA, 1] - u[iA, 2])
         f[iB] = D_B * (u[iB, 1] - u[iB, 2])
     end
 
     ## Storage term of species A and B
-    function storage!(f, u, node)
+    function storage!(f, u, node, data)
         f[iA] = u[iA]
         f[iB] = u[iB]
     end
 
     ## Source term for species a around 0.5
-    function source!(f, node)
+    function source!(f, node, data)
         x1 = node[1] - 0.5
         f[iA] = exp(-100 * x1^2)
     end
@@ -110,7 +110,7 @@ function main(; n = 10, Plotter = nothing, verbose = false, tend = 1,
     R_AC(u_A, u_C) = kp_AC * u_A * (1 - u_C) - km_AC * u_C
     R_BC(u_B, u_C) = kp_BC * u_B * (1 - u_C) - km_BC * u_C
 
-    function breaction!(f, u, node)
+    function breaction!(f, u, node, data)
         if node.region == 1
             f[iA] = S * R_AC(u[iA], u[iC])
             f[iB] = S * R_BC(u[iB], u[iC])
@@ -119,7 +119,7 @@ function main(; n = 10, Plotter = nothing, verbose = false, tend = 1,
     end
 
     ## This is for the term \partial_t u_C at the boundary
-    function bstorage!(f, u, node)
+    function bstorage!(f, u, node, data)
         if node.region == 1
             f[iC] = u[iC]
         end

--- a/examples/Example120_ThreeRegions1D.jl
+++ b/examples/Example120_ThreeRegions1D.jl
@@ -31,7 +31,7 @@ function main(; n = 30, Plotter = nothing, plot_grid = false, verbose = false,
     eps = [1, 1, 1]
     k = [1, 1, 1]
 
-    function reaction(f, u, node)
+    function reaction(f, u, node, data)
         if node.region == 1
             f[1] = k[1] * u[1]
             f[2] = -k[1] * u[1]
@@ -43,7 +43,7 @@ function main(; n = 30, Plotter = nothing, plot_grid = false, verbose = false,
         end
     end
 
-    function source(f, node)
+    function source(f, node, data)
         if node.region == 1
             f[1] = 1.0e-4 * (3.0 - node[1])
         end
@@ -54,20 +54,20 @@ function main(; n = 30, Plotter = nothing, plot_grid = false, verbose = false,
         ## write into the result also where
         ## the corresponding species has not been enabled
         ## Species information is used to prevent the assembly.
-        flux = function (f, u, edge)
+        flux = function (f, u, edge, data)
             for i = 1:3
                 f[i] = eps[i] * (u[i, 1] - u[i, 2])
             end
         end
 
-        storage = function (f, u, node)
+        storage = function (f, u, node, data)
             f .= u
         end
     else
         ## This is the "old" way:
         ## Write into result only where
         ## the corresponding species has been enabled
-        flux = function (f, u, edge)
+        flux = function (f, u, edge, data)
             if edge.region == 1
                 f[1] = eps[1] * (u[1, 1] - u[1, 2])
                 f[2] = eps[2] * (u[2, 1] - u[2, 2])
@@ -79,7 +79,7 @@ function main(; n = 30, Plotter = nothing, plot_grid = false, verbose = false,
             end
         end
 
-        storage = function (f, u, node)
+        storage = function (f, u, node, data)
             if node.region == 1
                 f[1] = u[1]
                 f[2] = u[2]

--- a/examples/Example121_PoissonPointCharge1D.jl
+++ b/examples/Example121_PoissonPointCharge1D.jl
@@ -40,16 +40,16 @@ function main(; nref = 0, Plotter = nothing, verbose = false, unknown_storage = 
 
     Q::Float64 = 0.0
 
-    function flux!(f, u, edge)
+    function flux!(f, u, edge, data)
         f[1] = u[1, 1] - u[1, 2]
     end
-    function storage!(f, u, node)
+    function storage!(f, u, node, data)
         f[1] = u[1]
     end
 
     ## Define boundary reaction defining charge
     ## Note that the term  is written on  the left hand side, therefore the - sign
-    function breaction!(f, u, node)
+    function breaction!(f, u, node, data)
         if node.region == 3
             f[1] = -Q
         end

--- a/examples/Example125_TestFunctions1D.jl
+++ b/examples/Example125_TestFunctions1D.jl
@@ -19,13 +19,13 @@ function main(; n = 100, Plotter = nothing, verbose = false, unknown_storage = :
     eps::Vector{Float64} = [1, 1.0e-1]
 
     physics = VoronoiFVM.Physics(
-                                 ; reaction = function (f, u, node)
+                                 ; reaction = function (f, u, node, data)
                                      f[1] = 10 * (u[1] - u[2])
                                      f[2] = 10 * (u[2] - u[1])
-                                 end, flux = function (f, u, edge)
+                                 end, flux = function (f, u, edge, data)
                                      f[1] = eps[1] * (u[1, 1] - u[1, 2])
                                      f[2] = eps[2] * (u[2, 1] - u[2, 2])
-                                 end, storage = function (f, u, node)
+                                 end, storage = function (f, u, node, data)
                                      f[1] = u[1]
                                      f[2] = u[2]
                                  end)

--- a/examples/Example201_Laplace2D.jl
+++ b/examples/Example201_Laplace2D.jl
@@ -14,7 +14,7 @@ import Metis
 
 ## Flux function which describes the flux
 ## between neighboring control volumes
-function g!(f, u, edge)
+function g!(f, u, edge, data)
     f[1] = u[1, 1] - u[1, 2]
 end
 

--- a/examples/Example203_CoordinateSystems.jl
+++ b/examples/Example203_CoordinateSystems.jl
@@ -17,7 +17,7 @@ function plot(grid, numerical, exact, Plotter)
     scalarplot!(vis[2, 1], grid, exact; title = "exact", show = true)
 end
 
-function flux(f, u, edge)
+function flux(f, u, edge, data)
     f[1] = u[1, 1] - u[1, 2]
 end
 
@@ -41,7 +41,7 @@ function maindisk(; nref = 0, r2 = 5.0, Plotter = nothing, assembly = :edgewise)
     R = collect(0:h:r2)
     grid = simplexgrid(R)
     circular_symmetric!(grid)
-    source(f, node) = f[1] = 1.0
+    source(f, node, data) = f[1] = 1.0
     sys = VoronoiFVM.System(grid; source, flux, species = [1], assembly = assembly)
     boundary_dirichlet!(sys; species = 1, region = 2, value = 0.0)
     sol = solve(sys)
@@ -70,7 +70,7 @@ function maincylinder(;
     Z = collect(z1:h:z2)
     grid = simplexgrid(R, Z)
     circular_symmetric!(grid)
-    source(f, node) = f[1] = 1.0
+    source(f, node, data) = f[1] = 1.0
     sys = VoronoiFVM.System(grid; source, flux, species = [1], assembly = assembly)
     boundary_dirichlet!(sys; species = 1, region = 2, value = 0.0)
     sol = solve(sys)
@@ -101,7 +101,7 @@ function maincylinder_unstruct(;
     h = 0.1 * 2.0^(-nref)
     grid = simplexgrid(joinpath(pkgdir(VoronoiFVM), "assets", "cyl_unstruct.sg"))
     circular_symmetric!(grid)
-    source(f, node) = f[1] = 1.0
+    source(f, node, data) = f[1] = 1.0
     sys = VoronoiFVM.System(grid; source, flux, species = [1], assembly = assembly)
     boundary_dirichlet!(sys; species = 1, region = 2, value = 0.0)
     sol = solve(sys)
@@ -129,7 +129,7 @@ function mainring(; nref = 0, r1 = 1.0, r2 = 5.0, Plotter = nothing, assembly = 
     R = collect(r1:h:r2)
     grid = simplexgrid(R)
     circular_symmetric!(grid)
-    source(f, node) = f[1] = 0.0
+    source(f, node, data) = f[1] = 0.0
     sys = VoronoiFVM.System(grid; source, flux, species = [1], assembly = assembly)
     boundary_dirichlet!(sys; species = 1, region = 1, value = 1.0)
     boundary_dirichlet!(sys; species = 1, region = 2, value = 0.0)
@@ -158,7 +158,7 @@ function maincylindershell(;
     Z = collect(z1:h:z2)
     grid = simplexgrid(R, Z)
     circular_symmetric!(grid)
-    source(f, node) = f[1] = 0.0
+    source(f, node, data) = f[1] = 0.0
     sys = VoronoiFVM.System(grid; source, flux, species = [1], assembly = assembly)
     boundary_dirichlet!(sys; species = 1, region = 4, value = 1.0)
     boundary_dirichlet!(sys; species = 1, region = 2, value = 0.0)
@@ -188,7 +188,7 @@ function mainsphere(; nref = 0, r2 = 5.0, Plotter = nothing, assembly = :edgewis
     R = collect(0:h:r2)
     grid = simplexgrid(R)
     spherical_symmetric!(grid)
-    source(f, node) = f[1] = 1.0
+    source(f, node, data) = f[1] = 1.0
     sys = VoronoiFVM.System(grid; source, flux, species = [1], assembly = assembly)
     boundary_dirichlet!(sys; species = 1, region = 2, value = 0.0)
     sol = solve(sys)
@@ -221,7 +221,7 @@ function mainsphereshell(;
     R = collect(r1:h:r2)
     grid = simplexgrid(R)
     spherical_symmetric!(grid)
-    source(f, node) = f[1] = 0.0
+    source(f, node, data) = f[1] = 0.0
     sys = VoronoiFVM.System(grid; source, flux, species = [1], assembly = assembly)
     boundary_dirichlet!(sys; species = 1, region = 1, value = 1.0)
     boundary_dirichlet!(sys; species = 1, region = 2, value = 0.0)

--- a/examples/Example204_HagenPoiseuille.jl
+++ b/examples/Example204_HagenPoiseuille.jl
@@ -32,14 +32,14 @@ function main(; nref = 0, Plotter = nothing, D = 0.01, v = 1.0, tend = 100, cin 
     evelo = edgevelocities(grid, fhp)
     bfvelo = bfacevelocities(grid, fhp)
 
-    function flux!(f, u, edge)
+    function flux!(f, u, edge, data)
         vd = evelo[edge.index] / D
         bp = fbernoulli(vd)
         bm = fbernoulli(-vd)
         f[1] = D * (bp * u[1] - bm * u[2])
     end
 
-    function outflow!(f, u, node)
+    function outflow!(f, u, node, data)
         if node.region == 2
             f[1] = bfvelo[node.ibnode, node.ibface] * u[1]
         end

--- a/examples/Example205_StagnationPoint.jl
+++ b/examples/Example205_StagnationPoint.jl
@@ -50,14 +50,14 @@ function main(; nref = 0, gridname = nothing, Plotter = nothing, D = 0.01, v = 1
     evelo = edgevelocities(grid, frz)
     bfvelo = bfacevelocities(grid, frz)
 
-    function flux!(f, u, edge)
+    function flux!(f, u, edge, data)
         vd = evelo[edge.index] / D
         bp = fbernoulli(vd)
         bm = fbernoulli(-vd)
         f[1] = D * (bp * u[1] - bm * u[2])
     end
 
-    function outflow!(f, u, node)
+    function outflow!(f, u, node, data)
         if node.region == Γ_out
             f[1] = bfvelo[node.ibnode, node.ibface] * u[1]
         end

--- a/examples/Example206_JouleHeat.jl
+++ b/examples/Example206_JouleHeat.jl
@@ -61,24 +61,24 @@ function main(; nref = 0, Plotter = nothing, verbose = "and", unknown_storage = 
     λ::Float64 = 1
     c::Float64 = 1
 
-    function storage!(y, u, node)
+    function storage!(y, u, node, data)
         y[iT] = c * u[iT]
     end
 
     κ(T) = κ0 * exp(α * (T - T0))
 
-    function flux!(y, u, edge)
+    function flux!(y, u, edge, data)
         y[iϕ] = κ(y[iT]) * (u[iϕ, 1] - u[iϕ, 2])
         y[iT] = λ * (u[iT, 1] - u[iT, 2])
     end
 
     ## The convention in VoronoiFVM.jl is to have all terms depending on the solution
     ## on the left hand side of the equation. That is why we have the minus sign here.
-    function jouleheat!(y, u, edge)
+    function jouleheat!(y, u, edge, data)
         y[iT] = -κ(y[iT]) * (u[iϕ, 1] - u[iϕ, 2]) * (u[iϕ, 1] - u[iϕ, 2])
     end
 
-    function bcondition!(y, u, node)
+    function bcondition!(y, u, node, data)
         boundary_dirichlet!(y, u, node; species = iϕ, region = 1, value = -10)
         boundary_dirichlet!(y, u, node; species = iϕ, region = 2, value = 10)
 

--- a/examples/Example207_NonlinearPoisson2D.jl
+++ b/examples/Example207_NonlinearPoisson2D.jl
@@ -22,15 +22,15 @@ function main(; n = 10, Plotter = nothing, verbose = false, unknown_storage = :s
 
     eps = 1.0e-2
 
-    physics = VoronoiFVM.Physics(; reaction = function (f, u, node)
+    physics = VoronoiFVM.Physics(; reaction = function (f, u, node, data)
                                      f[1] = u[1]^2
-                                 end, flux = function (f, u, edge)
+                                 end, flux = function (f, u, edge, data)
                                      f[1] = eps * (u[1, 1]^2 - u[1, 2]^2)
-                                 end, source = function (f, node)
+                                 end, source = function (f, node, data)
                                      x1 = node[1] - 0.5
                                      x2 = node[2] - 0.5
                                      f[1] = exp(-20.0 * (x1^2 + x2^2))
-                                 end, storage = function (f, u, node)
+                                 end, storage = function (f, u, node, data)
                                      f[1] = u[1]
                                  end)
     sys = VoronoiFVM.System(grid, physics; unknown_storage, assembly = assembly)

--- a/examples/Example215_NonlinearPoisson2D_BoundaryReaction.jl
+++ b/examples/Example215_NonlinearPoisson2D_BoundaryReaction.jl
@@ -18,7 +18,7 @@ function main(; n = 10, Plotter = nothing, verbose = false, unknown_storage = :s
     grid = simplexgrid(X, Y)
 
     eps = 1.0e-2
-    physics = VoronoiFVM.Physics(; breaction = function (f, u, node)
+    physics = VoronoiFVM.Physics(; breaction = function (f, u, node, data)
                                      if node.region == 2
                                          f[1] = 1 * (u[1] - u[2])
                                          f[2] = 1 * (u[2] - u[1])
@@ -26,10 +26,10 @@ function main(; n = 10, Plotter = nothing, verbose = false, unknown_storage = :s
                                          f[1] = 0
                                          f[2] = 0
                                      end
-                                 end, flux = function (f, u, edge)
+                                 end, flux = function (f, u, edge, data)
                                      f[1] = eps * (u[1, 1] - u[1, 2])
                                      f[2] = eps * (u[2, 1] - u[2, 2])
-                                 end, storage = function (f, u, node)
+                                 end, storage = function (f, u, node, data)
                                      f[1] = u[1]
                                      f[2] = u[2]
                                  end)

--- a/examples/Example220_NonlinearPoisson2D_BoundarySpecies.jl
+++ b/examples/Example220_NonlinearPoisson2D_BoundarySpecies.jl
@@ -18,24 +18,24 @@ function main(; n = 10, Plotter = nothing, verbose = false, unknown_storage = :s
     k = 1.0
     eps::Float64 = 1.0
     physics = VoronoiFVM.Physics(;
-                                 breaction = function (f, u, node)
+                                 breaction = function (f, u, node, data)
                                      if node.region == 2
                                          f[1] = k * (u[1] - u[3])
                                          f[3] = k * (u[3] - u[1]) + k * (u[3] - u[2])
                                          f[2] = k * (u[2] - u[3])
                                      end
-                                 end, bstorage = function (f, u, node)
+                                 end, bstorage = function (f, u, node, data)
                                      if node.region == 2
                                          f[3] = u[3]
                                      end
-                                 end, flux = function (f, u, edge)
+                                 end, flux = function (f, u, edge, data)
                                      f[1] = eps * (u[1, 1] - u[1, 2])
                                      f[2] = eps * (u[2, 1] - u[2, 2])
-                                 end, source = function (f, node)
+                                 end, source = function (f, node, data)
                                      x1 = node[1] - 0.5
                                      x2 = node[2] - 0.5
                                      f[1] = exp(-20.0 * (x1^2 + x2^2))
-                                 end, storage = function (f, u, node)
+                                 end, storage = function (f, u, node, data)
                                      f[1] = u[1]
                                      f[2] = u[2]
                                  end)

--- a/examples/Example221_EquationBlockPrecon.jl
+++ b/examples/Example221_EquationBlockPrecon.jl
@@ -48,7 +48,7 @@ function main(;dim=1, nref=0, Plotter = nothing, plot_grid = false, verbose = fa
     eps = [1, 1, 1]
     k = [1, 1, 1]
 
-    function reaction(f, u, node)
+    function reaction(f, u, node, data)
         if node.region == 1
             f[1] = k[1] * u[1]
             f[2] = -k[1] * u[1]
@@ -60,13 +60,13 @@ function main(;dim=1, nref=0, Plotter = nothing, plot_grid = false, verbose = fa
         end
     end
 
-    function source(f, node)
+    function source(f, node, data)
         if node.region == 1
             f[1] = 1.0e-4 * (3.0 - node[1])
         end
     end
 
-    flux = function (f, u, edge)
+    flux = function (f, u, edge, data)
         if edge.region == 1
             f[1] = eps[1] * (u[1, 1] - u[1, 2])
             f[2] = eps[2] * (u[2, 1] - u[2, 2])
@@ -77,8 +77,8 @@ function main(;dim=1, nref=0, Plotter = nothing, plot_grid = false, verbose = fa
             f[3] = eps[3] * (u[3, 1] - u[3, 2])
         end
     end
-    
-    storage = function (f, u, node)
+
+    storage = function (f, u, node, data)
         if node.region == 1
             f[1] = u[1]
             f[2] = u[2]

--- a/examples/Example225_TestFunctions2D.jl
+++ b/examples/Example225_TestFunctions2D.jl
@@ -126,23 +126,23 @@ function main(; n = 10, Plotter = nothing, verbose = false, unknown_storage = :s
         Γ_where_T_equal_0 = [4]
     end
 
-    function storage(f, u, node)
+    function storage(f, u, node, data)
         f .= u
     end
 
-    function flux(f, u, edge)
+    function flux(f, u, edge, data)
         f[1] = u[1, 1] - u[1, 2]
         f[2] = u[2, 1] - u[2, 2]
     end
 
     r(u1, u2) = u1 - 0.1 * u2
 
-    function reaction(f, u, node)
+    function reaction(f, u, node, data)
         f[1] = r(u[1], u[2])
         f[2] = -r(u[1], u[2])
     end
 
-    function source(f, node)
+    function source(f, node, data)
         f[1] = 1.0
     end
 
@@ -179,7 +179,7 @@ function main(; n = 10, Plotter = nothing, verbose = false, unknown_storage = :s
     """
     Amount of species created by source term per unit time:
     """
-    F = integrate(system, (f, u, node) -> source(f, node), sol)
+    F = integrate(system, (f, u, node, data) -> source(f, node, data), sol)
 
     """
     Amount of  reaction per unit time:

--- a/examples/Example226_BoundaryIntegral.jl
+++ b/examples/Example226_BoundaryIntegral.jl
@@ -27,15 +27,15 @@ function main(; n = 10, Plotter = nothing, verbose = false, unknown_storage = :s
         Γ_where_T_equal_0 = [4]
     end
 
-    function storage(f, u, node)
+    function storage(f, u, node, data)
         f .= u
     end
 
-    function flux(f, u, edge)
+    function flux(f, u, edge, data)
         f[1] = u[1, 1] - u[1, 2]
     end
 
-    function breaction(f, u, node)
+    function breaction(f, u, node, data)
         if node.region == Γ_where_T_equal_1[1]
             f[1] = u[1]^2
         end

--- a/examples/Example230_BoundaryFlux.jl
+++ b/examples/Example230_BoundaryFlux.jl
@@ -58,15 +58,15 @@ function main(; n = 2 * 10, # n musst be an even number
 
     #### discretization functions ####
 
-    function flux!(f, u, edge)
+    function flux!(f, u, edge, data)
         f[1] = d1 * (u[1, 1] - u[1, 2])
     end
 
-    function reaction!(f, u, node)
+    function reaction!(f, u, node, data)
         f[1] = k1[node.index] * u[1]
     end
 
-    function source!(f, node::VoronoiFVM.Node)
+    function source!(f, node::VoronoiFVM.Node, data)
         f[1] = c1[node.index]
     end
 
@@ -103,26 +103,26 @@ function main(; n = 2 * 10, # n musst be an even number
     c2 = 1.0
 
     #### discretization functions for bulk species ####
-    function flux2D!(f, u, edge)
+    function flux2D!(f, u, edge, data)
         f[ispec_2D] = d2 * (u[ispec_2D, 1] - u[ispec_2D, 2])
     end
 
-    function reaction2D!(f, u, node)
+    function reaction2D!(f, u, node, data)
         f[ispec_2D] = k2 * u[ispec_2D]
     end
 
-    function source2D!(f, node)
+    function source2D!(f, node, data)
         f[ispec_2D] = c2
     end
 
     #### discretization functions for boundary species at active boundary ####
-    function bflux!(f, u, bedge)
+    function bflux!(f, u, bedge, data)
         if bedge.region == active_boundary
             f[ispec_boundary] = db * (u[ispec_boundary, 1] - u[ispec_boundary, 2])
         end
     end
 
-    function breaction!(f, u, bnode)
+    function breaction!(f, u, bnode, data)
         if bnode.region == active_boundary
             if bnode.coord[2, bnode.index] <= 0.5
                 kb = kmax
@@ -134,7 +134,7 @@ function main(; n = 2 * 10, # n musst be an even number
         end
     end
 
-    function bsource!(f, bnode)
+    function bsource!(f, bnode, data)
         if bnode.region == active_boundary
             if bnode.coord[2, bnode.index] <= 0.5
                 cb = 0.0

--- a/examples/Example301_Laplace3D.jl
+++ b/examples/Example301_Laplace3D.jl
@@ -12,11 +12,11 @@ using GridVisualize
 
 ## Flux function which describes the flux
 ## between neighboring control volumes
-function g!(f, u, edge)
+function g!(f, u, edge, data)
     f[1] = u[1, 1] - u[1, 2]
 end
 
-function s(f, node)
+function s(f, node, data)
     n = view(node.coord, :, node.index)
     f[1] = n[1] * sin(5.0 * n[2]) * exp(n[3])
 end

--- a/examples/Example311_HeatEquation_BoundaryDiffusion.jl
+++ b/examples/Example311_HeatEquation_BoundaryDiffusion.jl
@@ -38,17 +38,17 @@ function main(n = 1; assembly = :edgewise)
     eps = 1.0e0  # bulk heat conduction coefficient
     eps_surf = 1.0e-2 # surface diffusion coefficient
     k = 1.0    # transmission coefficient
-    physics = VoronoiFVM.Physics(; flux = function (f, u, edge)
+    physics = VoronoiFVM.Physics(; flux = function (f, u, edge, data)
                                      f[1] = eps * (u[1, 1] - u[1, 2])
                                  end,
-                                 bflux = function (f, u, edge)
+                                 bflux = function (f, u, edge, data)
                                      if edge.region == breg
                                          f[2] = eps_surf * (u[2, 1] - u[2, 2])
                                      else
                                          f[2] = 0.0
                                      end
                                  end,
-                                 breaction = function (f, u, node)
+                                 breaction = function (f, u, node, data)
                                      if node.region == breg
                                          f[1] = k * (u[1] - u[2])
                                          f[2] = k * (u[2] - u[1])
@@ -57,16 +57,16 @@ function main(n = 1; assembly = :edgewise)
                                          f[2] = 0.0
                                      end
                                  end,
-                                 bsource = function (f, bnode)
+                                 bsource = function (f, bnode, data)
                                      x1 = bnode[1] - 0.5
                                      x2 = bnode[2] - 0.5
                                      x3 = bnode[3] - 0.5
                                      f[2] = 1.0e4 * exp(-20.0 * (x1^2 + x2^2 + x3^2))
-                                 end, bstorage = function (f, u, node)
+                                 end, bstorage = function (f, u, node, data)
                                      if node.region == breg
                                          f[2] = u[2]
                                      end
-                                 end, storage = function (f, u, node)
+                                 end, storage = function (f, u, node, data)
                                      f[1] = u[1]
                                  end)
 

--- a/examples/Example406_WeirdReaction.jl
+++ b/examples/Example406_WeirdReaction.jl
@@ -72,19 +72,19 @@ function main(; n = 10,
     ## Diffusion flux for species A and B
     D_A = 1.0
     D_B = 1.0e-2
-    function flux!(f, u, edge)
+    function flux!(f, u, edge, data)
         f[iA] = D_A * (u[iA, 1] - u[iA, 2])
         f[iB] = D_B * (u[iB, 1] - u[iB, 2])
     end
 
     ## Storage term of species A and B
-    function storage!(f, u, node)
+    function storage!(f, u, node, data)
         f[iA] = u[iA]
         f[iB] = u[iB]
     end
 
     ## Source term for species a around 0.5
-    function source!(f, node)
+    function source!(f, node, data)
         x1 = node[1] - 0.5
         f[iA] = exp(-100 * x1^2)
     end
@@ -94,7 +94,7 @@ function main(; n = 10,
     kp_AB = 1.0
     km_AB = 0.1
 
-    function breaction!(f, u, node)
+    function breaction!(f, u, node, data)
         if node.region == 1
             R = kp_AB * exp(u[iC]) * u[iA] - exp(-u[iC]) * km_AB * u[iB]
             f[iA] += R

--- a/examples/Example410_ManySpecies.jl
+++ b/examples/Example410_ManySpecies.jl
@@ -17,7 +17,7 @@ using LinearAlgebra
 function main(; n = 11, nspec = 50, Plotter = nothing, unknown_storage = :dense, assembly = :edgewise)
     grid = simplexgrid(range(0, 1; length = n))
 
-    function flux(f, u, edge)
+    function flux(f, u, edge, data)
         for ispec = 1:nspec
             f[ispec] = u[ispec, 1] - u[ispec, 2]
         end

--- a/examples/Example420_DiscontinuousQuantities.jl
+++ b/examples/Example420_DiscontinuousQuantities.jl
@@ -74,7 +74,7 @@ function main(; N = 5, Plotter = nothing, unknown_storage = :sparse, assembly = 
 
     ##For both quantities, we define simple diffusion fluxes:
 
-    function flux(f, u, edge)
+    function flux(f, u, edge, data)
         f[dspec] = u[dspec, 1] - u[dspec, 2]
         f[cspec] = u[cspec, 1] - u[cspec, 2]
     end
@@ -82,7 +82,7 @@ function main(; N = 5, Plotter = nothing, unknown_storage = :sparse, assembly = 
     d1 = 1
     q1 = 0.2
 
-    function breaction(f, u, bnode)
+    function breaction(f, u, bnode, data)
 
         # left outer boundary value for dspec
         if bnode.region == 1

--- a/examples/Example421_AbstractQuantities_TestFunctions.jl
+++ b/examples/Example421_AbstractQuantities_TestFunctions.jl
@@ -67,7 +67,7 @@ function main(; N = 3, Plotter = nothing, unknown_storage = :sparse, assembly = 
     ##########################################################
     icc = 1 # for system without AbstractQuantities
 
-    function flux!(f, u, edge) # analogous as for other system
+    function flux!(f, u, edge, data) # analogous as for other system
         f[icc] = u[icc, 1] - u[icc, 2]
     end
 

--- a/examples/Example422_InterfaceQuantities.jl
+++ b/examples/Example422_InterfaceQuantities.jl
@@ -68,7 +68,7 @@ function main(; n = 5, Plotter = nothing, tend = 20.0, unknown_storage = :sparse
     NA = [10.0, 0.0]
     ND = [0.0, 10.0]
 
-    function storage!(f, u, node)
+    function storage!(f, u, node, data)
         etan = -((u[iphin] - u[ipsi]))
         etap = ((u[iphip] - u[ipsi]))
 
@@ -78,7 +78,7 @@ function main(; n = 5, Plotter = nothing, tend = 20.0, unknown_storage = :sparse
         f[ipsi] = 0.0
     end
 
-    function reaction!(f, u, node)
+    function reaction!(f, u, node, data)
         etan = -((u[iphin] - u[ipsi]))
         etap = ((u[iphip] - u[ipsi]))
 
@@ -91,7 +91,7 @@ function main(; n = 5, Plotter = nothing, tend = 20.0, unknown_storage = :sparse
         f[iphip] = recomb
     end
 
-    function flux!(f, u, node)
+    function flux!(f, u, node, data)
         f[ipsi] = -(u[ipsi, 2] - u[ipsi, 1])
 
         ########################
@@ -107,7 +107,7 @@ function main(; n = 5, Plotter = nothing, tend = 20.0, unknown_storage = :sparse
         f[iphip] = -(bp * exp(etap2) - bm * exp(etap1))
     end
 
-    function breaction!(f, u, bnode)
+    function breaction!(f, u, bnode, data)
         if bnode.region == bjunction
             # left values
             nleft = exp(-((u[iphin, 1] - u[ipsi])))
@@ -136,7 +136,7 @@ function main(; n = 5, Plotter = nothing, tend = 20.0, unknown_storage = :sparse
         end
     end
 
-    function bstorage!(f, u, bnode)
+    function bstorage!(f, u, bnode, data)
         f[ipsi] = 0.0
 
         if bnode.region == bjunction

--- a/examples/Example430_ParameterDerivativesStationary.jl
+++ b/examples/Example430_ParameterDerivativesStationary.jl
@@ -27,15 +27,15 @@ function f(P; n = 10)
     nspecies = 1
     ispec = 1
 
-    function flux!(f, u, edge)
+    function flux!(f, u, edge, data)
         f[1] = (1 + p) * (u[1, 1]^2 - u[1, 2]^2)
     end
 
-    function r!(f, u, edge)
+    function r!(f, u, edge, data)
         f[1] = p * u[1]^5
     end
 
-    function bc!(f, u, node)
+    function bc!(f, u, node, data)
         boundary_dirichlet!(f, u, node, ispec, 1, 0.0)
         boundary_dirichlet!(f, u, node, ispec, 3, p)
     end
@@ -139,17 +139,17 @@ end
 
 #########################################################################
 
-function fluxh!(f, u, edge)
+function fluxh!(f, u, edge, data)
     p = parameters(u)[1]
     f[1] = (1 + p) * (u[1, 1]^2 - u[1, 2]^2)
 end
 
-function rh!(f, u, edge)
+function rh!(f, u, edge, data)
     p = parameters(u)[1]
     f[1] = p * u[1]^5
 end
 
-function bch!(f, u, node)
+function bch!(f, u, node, data)
     p = parameters(u)[1]
     boundary_dirichlet!(f, u, node, 1, 1, 0.0)
     boundary_dirichlet!(f, u, node, 1, 3, p)

--- a/pluto-examples/api-update.jl
+++ b/pluto-examples/api-update.jl
@@ -77,25 +77,25 @@ n = 100
 begin
     h = 1.0 / convert(Float64, n)
     const eps = 1.0e-2
-    function reaction(f, u, node)
+    function reaction(f, u, node, data)
         f[1] = u[1]^2
     end
 
-    function flux(f, u, edge)
+    function flux(f, u, edge, data)
         f[1] = eps * (u[1, 1]^2 - u[1, 2]^2)
     end
 
-    function source(f, node)
+    function source(f, node, data)
         x1 = node[1] - 0.5
         x2 = node[2] - 0.5
         f[1] = exp(-20.0 * (x1^2 + x2^2))
     end
 
-    function storage(f, u, node)
+    function storage(f, u, node, data)
         f[1] = u[1]
     end
 
-    function bcondition(f, u, node)
+    function bcondition(f, u, node, data)
         boundary_dirichlet!(f,
                             u,
                             node;
@@ -265,7 +265,7 @@ The following example gives some information in this respect:
 D = 0.1
 
 # ╔═╡ 2ff77259-7a81-4c54-a291-cbc20ee56c5d
-function xflux(f, u, edge)
+function xflux(f, u, edge, data)
     f[1] = D * (u[1, 1]^2 - u[1, 2]^2)
 end
 
@@ -300,7 +300,7 @@ But we can also look for the reasons of the allocations. Here, global values sho
 const D1 = 0.1
 
 # ╔═╡ c40f1954-4fb7-48b2-ab4c-cdf6459b7383
-function xflux1(f, u, edge)
+function xflux1(f, u, edge, data)
     f[1] = D1 * (u[1, 1]^2 - u[1, 2]^2)
 end
 
@@ -331,14 +331,14 @@ The `VoronoiFVM.Physics` struct almost never was used outside of the constructor
 grid1 = simplexgrid(0:0.1:1);
 
 # ╔═╡ 90bbf212-c6c8-44f0-8132-4a98f094750e
-function multispecies_flux(y, u, edge)
+function multispecies_flux(y, u, edge, data)
     for i = 1:(edge.nspec)
         y[i] = u[i, 1] - u[i, 2]
     end
 end
 
 # ╔═╡ adff41d1-9398-4a66-9a8e-e03809973fa6
-function test_reaction(y, u, node)
+function test_reaction(y, u, node, data)
     y[1] = u[1]
     y[2] = -u[1]
 end
@@ -376,7 +376,7 @@ space and time dependent boundary conditions. One can specify them either in `br
 """
 
 # ╔═╡ ec188c81-3374-4eed-9b7e-e22350886df2
-function bcond2(y, u, bnode)
+function bcond2(y, u, bnode, data)
     boundary_neumann!(y, u, bnode; species = 1, region = 1, value = sin(bnode.time))
     boundary_dirichlet!(y, u, bnode; species = 2, region = 2, value = 0)
 end;
@@ -429,7 +429,7 @@ This example also demonstrates position dependent boundary values.
 """
 
 # ╔═╡ a71086fa-4ec6-4842-a4e1-6a6b60441fc2
-function bcond3(y, u, bnode)
+function bcond3(y, u, bnode, data)
     boundary_dirichlet!(y, u, bnode; region = 4, value = bnode[2])
     boundary_dirichlet!(y, u, bnode; region = 2, value = -bnode[2])
 end;
@@ -469,10 +469,10 @@ Another new keyword argument is `inival` which allows to pass an initial value w
 """
 
 # ╔═╡ 1e12afcf-cf46-4672-9434-44fa8af95ef7
-reaction4(y, u, bnode) = y[1] = -bnode[1]^2 + u[1]^4;
+reaction4(y, u, bnode, data) = y[1] = -bnode[1]^2 + u[1]^4;
 
 # ╔═╡ 938ef63c-58c4-41a0-b3dd-4eb76987a4d7
-bc4(args...) = boundary_dirichlet!(args...; value = 0);
+bc4(f, u, node, data) = boundary_dirichlet!(f, u, node; value = 0);
 
 # ╔═╡ fe424654-f070-46a9-850a-738b1d4aca8f
 system4 = VoronoiFVM.System(-10:0.1:10;

--- a/pluto-examples/flux-reconstruction.jl
+++ b/pluto-examples/flux-reconstruction.jl
@@ -239,13 +239,13 @@ md"""
 src(x) = exp(-x^2 / 0.01)
 
 # ╔═╡ aec97834-1612-49ab-a19b-7fd74c83228f
-source1d(y, node) = y[1] = src(node[1])
+source1d(y, node, data) = y[1] = src(node[1])
 
 # ╔═╡ 387f52d0-926e-445d-9e3e-afebbc7207f6
-flux1d(y, u, edge) = y[1] = u[1, 1]^2 - u[1, 2]^2
+flux1d(y, u, edge, data) = y[1] = u[1, 1]^2 - u[1, 2]^2
 
 # ╔═╡ 3793696c-c934-4e56-a1e7-887fc2181970
-function bc1d(y, u, bnode)
+function bc1d(y, u, bnode, data)
     boundary_dirichlet!(y, u, bnode; region = 1, value = 0.01)
     boundary_dirichlet!(y, u, bnode; region = 2, value = 0.01)
 end

--- a/pluto-examples/interfaces1d.jl
+++ b/pluto-examples/interfaces1d.jl
@@ -114,7 +114,7 @@ Define the diffusion flux for the two species in their respective subdomains
 """
 
 # ╔═╡ 6aabfbe1-de7d-49ba-8144-6d364b21b34f
-function flux!(f, u, edge)
+function flux!(f, u, edge, data)
     if edge.region == 1
         f[1] = u[1, 1] - u[1, 2]
     end
@@ -206,7 +206,7 @@ This means we set ``f_1(u_1,u_2)=0`` and ``f_2(u_1,u_2)=0``.
 """
 
 # ╔═╡ 8f210696-fcf4-47bc-a5a2-c561ad7efcbd
-function noreaction(f, u, node) end
+function noreaction(f, u, node, data) end
 
 # ╔═╡ 57e8515e-3be1-4478-af98-430501438ee7
 system1 = make_system(noreaction);
@@ -248,7 +248,7 @@ begin
 end
 
 # ╔═╡ 1328b4bf-2d64-4b02-a910-1995da8be28b
-function mal_reaction(f, u, node)
+function mal_reaction(f, u, node, data)
     if node.region == 3
         react = k1 * u[1] - k2 * u[2]
         f[1] = react
@@ -281,7 +281,7 @@ Setting ``k_1,k_2`` to a large number leads to another special case of the above
 """
 
 # ╔═╡ 9eaea813-2628-47d0-9d36-54c367689142
-function penalty_reaction(f, u, node)
+function penalty_reaction(f, u, node, data)
     if node.region == 3
         react = 1.0e10 * (u[1] - u[2])
         f[1] = react
@@ -306,7 +306,7 @@ Instead of enforcing continuity, one can enforce a fixed jump.
 const jump = 0.2
 
 # ╔═╡ 7331db49-7ace-468e-87d8-56ab5d900905
-function penalty_jump_reaction(f, u, node)
+function penalty_jump_reaction(f, u, node, data)
     if node.region == 3
         react = 1.0e10 * (u[1] - u[2] - jump)
         f[1] = react
@@ -341,7 +341,7 @@ According to the mass action law, this is implemented via
 const k_r = 1000
 
 # ╔═╡ 39a0db1b-3a4e-4108-b43f-d4e578c92608
-function recombination(f, u, node)
+function recombination(f, u, node, data)
     if node.region == 3
         react = k_r * (u[1] * u[2])
         f[1] = react
@@ -389,7 +389,7 @@ and therefore another special case of the mass action law condition.
 const d = 1
 
 # ╔═╡ 58d8831b-ad66-4f77-a33a-933c15c46a52
-function thinlayer(f, u, node)
+function thinlayer(f, u, node, data)
     if node.region == 3
         react = (u[1] - u[2]) / d
         f[1] = react
@@ -477,7 +477,7 @@ For both quantities, we define simple diffusion fluxes:
 """
 
 # ╔═╡ 719f206a-5b9f-4d78-8778-1d89edb2bc4d
-function flux2(f, u, edge)
+function flux2(f, u, edge, data)
     f[dspec] = u[dspec, 1] - u[dspec, 2]
     f[cspec] = u[cspec, 1] - u[cspec, 2]
 end
@@ -503,7 +503,7 @@ const d1 = 0.1
 const q1 = 0.2
 
 # ╔═╡ d6e1c6c7-060d-4c2f-8054-d8f33f54bd55
-function breaction2(f, u, node)
+function breaction2(f, u, node, data)
     if node.region > 2
         react = (u[dspec, 1] - u[dspec, 2]) / d1
         f[dspec, 1] = react

--- a/pluto-examples/nonlinear-solvers.jl
+++ b/pluto-examples/nonlinear-solvers.jl
@@ -51,17 +51,17 @@ Define a nonlinear Poisson equation to have an example. Let ``Ω=(0,10)`` and de
 X = 0:0.001:1
 
 # ╔═╡ c8eda836-d719-4412-895e-c3a24fec21ec
-flux(y, u, edge) = y[1] = u[1, 1] - u[1, 2];
+flux(y, u, edge, data) = y[1] = u[1, 1] - u[1, 2];
 
 # ╔═╡ c09f5dfc-fc47-4952-8051-54731ec2b00b
-function reaction(y, u, node)
+function reaction(y, u, node, data)
     eplus = exp(u[1])
     eminus = 1 / eplus
     y[1] = eplus - eminus
 end
 
 # ╔═╡ eab04557-5084-4174-b275-b4d4399238e5
-function bc(y, u, node)
+function bc(y, u, node, data)
     boundary_dirichlet!(y, u, node; region = 1, value = 100)
     boundary_dirichlet!(y, u, node; region = 2, value = 0.0)
 end;
@@ -194,7 +194,7 @@ If the solution is unsuccessful, the parameter stepsize is halved and solution i
 """
 
 # ╔═╡ a71cbcd4-310e-47a8-94f9-1159995a7711
-function pbc(y, u, node)
+function pbc(y, u, node, data)
     boundary_dirichlet!(y, u, node; region = 1, value = 100 * embedparam(node))
     boundary_dirichlet!(y, u, node; region = 2, value = 0)
 end;
@@ -202,8 +202,8 @@ end;
 # ╔═╡ 89435c65-0520-4430-8727-9d013df6182d
 system2 = VoronoiFVM.System(X;
                             flux = flux,
-                            reaction = function (y, u, node)
-                                reaction(y, u, node)
+                            reaction = function (y, u, node, data)
+                                reaction(y, u, node, data)
 
                                 y[1] = y[1] * embedparam(node)
                             end,

--- a/pluto-examples/ode-brusselator.jl
+++ b/pluto-examples/ode-brusselator.jl
@@ -61,19 +61,19 @@ end;
 
 
 # ╔═╡ 2fb1c53a-7ff8-4ac9-ae78-83bcbc57c926
-function bruss_storage(f,u,node)
+function bruss_storage(f,u,node,data)
 	f[1]=u[1]
 	f[2]=u[2]
 end;
 
 # ╔═╡ 71b7e770-5cd4-4671-a76a-8e29eda04eec
-function bruss_diffusion(f,u,edge)
+function bruss_diffusion(f,u,edge,data)
 	f[1]=bruss_D_1*(u[1,1]-u[1,2])
-	f[2]=bruss_D_2*(u[2,1]-u[2,2])	
+	f[2]=bruss_D_2*(u[2,1]-u[2,2])
 end;
 
 # ╔═╡ f1e7a242-d631-4624-b0c0-ac44f139d77c
-function bruss_reaction(f,u,node)
+function bruss_reaction(f,u,node,data)
     f[1]= (bruss_B+1.0)*u[1]-bruss_A-u[1]^2*u[2]
     f[2]= u[1]^2*u[2]-bruss_B*u[1]
 end;

--- a/pluto-examples/ode-diffusion1d.jl
+++ b/pluto-examples/ode-diffusion1d.jl
@@ -73,11 +73,11 @@ function create_porous_medium_problem(n,m)
     X=collect(-1:h:1)
     grid=VoronoiFVM.Grid(X)
 
-    function flux!(f,u,edge)
+    function flux!(f,u,edge,data)
         f[1]=u[1,1]^m-u[1,2]^m
     end
 
-    storage!(f,u,node)= f[1]=u[1]
+    storage!(f,u,node,data)= f[1]=u[1]
 
 	sys=VoronoiFVM.System(grid,flux=flux!,storage=storage!, species=1)
     sys,X

--- a/pluto-examples/ode-nlstorage1d.jl
+++ b/pluto-examples/ode-nlstorage1d.jl
@@ -90,7 +90,7 @@ md"""
 """
 
 # ╔═╡ 54aef797-210b-4eea-95b4-e0bdcb478c1d
-    function flux!(f,u,edge)
+    function flux!(f,u,edge,data)
         f[1]=u[1,1]-u[1,2]
     end
 
@@ -100,7 +100,7 @@ Storage term needs to be regularized as its derivative at 0 is infinity:
 """
 
 # ╔═╡ 3790d063-8a3d-429b-8a59-05cfc35b6878
-    function storage!(f,u,node)
+    function storage!(f,u,node,data)
         f[1]=(ε+u[1])^(1.0/m)
     end
 
@@ -136,12 +136,12 @@ we see that the problem structure does not fit into the setting of that package 
 """
 
 # ╔═╡ d495a088-69dd-4f4e-964c-88638958799a
-function dae_storage!(y,u,node)
+function dae_storage!(y,u,node,data)
 	y[1]=u[2]
 end
 
 # ╔═╡ 4c09ec49-c4d6-4c5a-8f73-8a736acaff61
-function dae_reaction!(y,u,node)
+function dae_reaction!(y,u,node,data)
 	y[2]= u[2]^m-u[1]
 end
 

--- a/pluto-examples/problemcase.jl
+++ b/pluto-examples/problemcase.jl
@@ -334,19 +334,19 @@ function trsolve(grid;
                  Δp = 1.0,
                  ϕ = [1, 1],
                  tend = 100,)
-    function flux(y, u, edge)
+    function flux(y, u, edge, data)
         y[ip] = κ[edge.region] * (u[ip, 1] - u[ip, 2])
         bp, bm = fbernoulli_pm(y[ip] / D[edge.region])
         y[ic] = D[edge.region] * (bm * u[ic, 1] - bp * u[ic, 2])
     end
 
-    function stor(y, u, node)
+    function stor(y, u, node, data)
         y[ip] = 0
         y[ic] = ϕ[node.region] * u[ic]
     end
 
     dim = dim_space(grid)
-    function bc(y, u, bnode)
+    function bc(y, u, bnode, data)
         c0 = ramp(bnode.time; dt = (0, 0.001), du = (0, 1))
         boundary_dirichlet!(y, u, bnode, ic, Γ_in, c0)
         boundary_dirichlet!(y, u, bnode, ic, Γ_out, 0)
@@ -466,16 +466,16 @@ md"""
 
 # ╔═╡ bb3a50ed-32e7-4305-87d8-4093c054a4d2
 function rdsolve(grid; D = [1.0e-12, 1.0], R = [1, 0.1])
-    function flux(y, u, edge)
+    function flux(y, u, edge, data)
         y[1] = D[edge.region] * (u[1, 1] - u[1, 2])
     end
 
-    function rea(y, u, node)
+    function rea(y, u, node, data)
         y[1] = R[node.region] * u[1]
     end
-    function bc(args...)
-        boundary_dirichlet!(args..., 1, Γ_in, 1)
-        boundary_dirichlet!(args..., 1, Γ_out, 0)
+    function bc(y, u, bnode, data)
+        boundary_dirichlet!(y, u, bnode, 1, Γ_in, 1)
+        boundary_dirichlet!(y, u, bnode, 1, Γ_out, 0)
     end
     sys = VoronoiFVM.System(grid;
                             flux = flux,

--- a/src/vfvm_postprocess.jl
+++ b/src/vfvm_postprocess.jl
@@ -8,7 +8,7 @@ Base.setindex!(I::SolutionIntegral, v, ispec::Integer, ireg) = I.value[ispec, ir
 
 ################################################################
 """
-    integrate(system,F,U; boundary=false)    
+    integrate(system,F,U; boundary=false)
 
 Integrate node function (same signature as reaction or storage)
  `F` of  solution vector region-wise over domain or boundary.
@@ -70,7 +70,7 @@ function integrate(system::AbstractSystem{Tv, Tc, Ti, Tm}, F::Function, U::Abstr
 end
 
 """
-    integrate(system,F,U; boundary=false)    
+    integrate(system,F,U; boundary=false)
 
 Integrate solution vector region-wise over domain or boundary.
 The result is an `nspec x nregion` matrix.
@@ -84,7 +84,7 @@ end
 
 
 """
-    edgeintegrate(system,F,U; boundary=false)    
+    edgeintegrate(system,F,U; boundary=false)
 
 Integrate edge function (same signature as flux function)
  `F` of  solution vector region-wise over domain or boundary.
@@ -139,7 +139,7 @@ $(SIGNATURES)
 Reconstruction of  edge flux as  vector function  on the nodes  of the
 triangulation.  The result  can be seen as a  piecewiesw linear vector
 function in the FEM space spanned by the discretization nodes exhibiting
-the flux density.  
+the flux density.
 
 The reconstruction is based on the  "magic formula"
 R. Eymard, T. Gallouet, R. Herbin, IMA Journal of Numerical Analysis (2006)
@@ -157,7 +157,7 @@ Example:
     reveal(vis)
 ```
 
-CAVEAT: there is a possible unsolved problem with the values at domain 
+CAVEAT: there is a possible unsolved problem with the values at domain
 corners in the code. Please see any potential boundary artifacts as a manifestation
 of this issue and report them.
 """
@@ -242,7 +242,7 @@ end
 """
     $(SIGNATURES)
 
-Calculate weigthed discrete ``L^2(\\Omega)`` norm of a solution vector. 
+Calculate weigthed discrete ``L^2(\\Omega)`` norm of a solution vector.
 """
 function l2norm(sys, u, species_weights = ones(num_species(sys)))
     _complete!(sys)
@@ -373,7 +373,7 @@ Return non-Delaunay edges. Returns a vector of tuples:
 Each tuple consists of `(node1, node2, edge factor, region)`
 
 If the vector has length 0, the grid is boundary conforming Delaunay
-with respect to each cell region. This means that up to `tol`, all 
+with respect to each cell region. This means that up to `tol`, all
 edge form factors are nonnegative.
 """
 function nondelaunay(grid; tol = 1.0e-16, verbose = false)

--- a/src/vfvm_testfunctions.jl
+++ b/src/vfvm_testfunctions.jl
@@ -32,10 +32,10 @@ $(TYPEDSIGNATURES)
 Constructor for TestFunctionFactory from System
 """
 function TestFunctionFactory(system::AbstractSystem; control = SolverControl())
-    physics = Physics(; flux = function (f, u, edge)
+    physics = Physics(; flux = function (f, u, edge, data)
                           f[1] = u[1] - u[2]
                       end,
-                      storage = function (f, u, node)
+                      storage = function (f, u, node, data)
                           f[1] = u[1]
                       end)
     tfsystem = System(system.grid, physics; unknown_storage = :dense)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,9 +19,9 @@ end
 
 function run_all_tests(; run_notebooks = false, notebooksonly = false)
     if !notebooksonly
-        # @testset "basictest" begin
-        #     run_tests_from_directory(@__DIR__, "test_")
-        # end
+        @testset "basictest" begin
+            run_tests_from_directory(@__DIR__, "test_")
+        end
 
         @testset "Development Examples" begin
             run_tests_from_directory(joinpath(@__DIR__, "..", "examples"), "Example0")

--- a/test/test_diffeq.jl
+++ b/test/test_diffeq.jl
@@ -6,13 +6,13 @@ using Test
 
 function test_matrices(nspec)
     grid = simplexgrid(0:1.0:5)
-    function flux(y, u, edge)
+    function flux(y, u, edge, data)
         for i = 1:length(y)
             y[i] = u[i, 1] - u[i, 2]
         end
     end
 
-    function storage(y, u, node)
+    function storage(y, u, node, data)
         for i = 1:length(y)
             y[i] = i * u[i]
         end

--- a/test/test_norms.jl
+++ b/test/test_norms.jl
@@ -30,7 +30,7 @@ function test_edgeint(; dim = 2, c = 1.0, assembly = :edgewise, h = 0.1)
     sys = VoronoiFVM.System(g; species = [1], assembly)
     VoronoiFVM._complete!(sys)
     u = map(c, sys)
-    function f(y, u, edge)
+    function f(y, u, edge, data=nothing)
         y[1] = 0.5 * (u[1, 1] + u[2, 1])
     end
     VoronoiFVM.edgeintegrate(sys, f, u)[1, 1]


### PR DESCRIPTION
This patch implements a warning that is triggered if the user constructs a VoronoiFVM.Physics object with a callback function that uses only three or two arguments, respectively.

All examples were overhauled to comply with the new interface. Hereby, the data=nothing default has to be set to allow calls with and without the data argument. This needs to be done to preserve the current checks for isdata() and hasdata().
The default can be removed once the deprecated code is removed.