### PR TITLE
Remove data deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
     solve!(solution,inival, system::VoronoiFVM.AbstractSystem; kwargs...)
 ````
    - History is now a field of the solution but not system, to be accessed with  ``history(sol)``, both for stationary and transient solutions
+   - [`VoronoiFVM.Physics`](@ref) callbacks (`flux`, `storage`, etc.) need a provided `data` argument
+
 ### Added
   - Introduced ``SystemState`` which contains entries (matrix, residuals) which before were
     part of ``System``

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
   - Stationary solutions are now subtypes of AbstractNoTimeSolution
   - Changelog now in package root
 
-## upcoming release
+## v1.25.0, Sept 9, 2024
 - [`VoronoiFVM.Physics`](@ref) callbacks (`flux`, `storage`, etc.) without `data` argument are now deprecated
 
 ## v1.24.0 August 20, 2024

--- a/src/vfvm_system.jl
+++ b/src/vfvm_system.jl
@@ -975,11 +975,7 @@ function _initialize_dirichlet!(U::AbstractMatrix, system::AbstractSystem{Tv, Tc
 
     # set up bnode
     bnode = BNode(system, time, λ, params)
-    bnodeparams = (bnode,)
     data = system.physics.data
-    if isdata(data)
-        bnodeparams = (bnode, data)
-    end
 
     # setup unknowns to be passed
     UK = zeros(Tv, num_species(system) + length(params))
@@ -999,7 +995,7 @@ function _initialize_dirichlet!(U::AbstractMatrix, system::AbstractSystem{Tv, Tc
             bnode.dirichlet_value .= Inf
             # set up solution vector, call boundary reaction
             @views UK[1:nspecies] .= U[:, bnode.index]
-            system.physics.breaction(y, u, bnodeparams...)
+            system.physics.breaction(y, u, bnode, data)
 
             # Check for Dirichlet bc
             for ispec = 1:nspecies


### PR DESCRIPTION
This PR removes the support for `Physics` callbacks without a `data` argument.
See also #122 