### PR TITLE
Fix/sparse matrix inival

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VoronoiFVM"
 uuid = "82b139dc-5afc-11e9-35da-9b9bdfd336f3"
 authors = ["Jürgen Fuhrmann <juergen.fuhrmann@wias-berlin.de>", "Patrick Jaap", "Dilara Abdel", "Jan Weidner", "Alexander Seiler", "Patricio Farrell", "Matthias Liero"]
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"

--- a/examples/Example440_ParallelState.jl
+++ b/examples/Example440_ParallelState.jl
@@ -35,7 +35,7 @@ function main(;nref=5, Plotter=nothing)
     masses=similar(influxes)
 
     ## Split the index range in as many chunks as threads
-    Threads.@threads for indexes in chunks(influxes;n=Threads.nthreads())
+    Threads.@threads for indexes in chunks(1:length(influxes);n=Threads.nthreads())
         ## Create a new state sharing the system - one for each chunk
         state=similar(state0)
         ## Solve for all data values in chunk

--- a/src/vfvm_sparsesolution.jl
+++ b/src/vfvm_sparsesolution.jl
@@ -54,6 +54,7 @@ $(SIGNATURES)
 Array of values in sparse solution array.
 """
 values(a::SparseSolutionArray) = a.u.nzval
+values(a::SparseMatrixCSC) = a.nzval
 
 Base.size(a::SparseSolutionArray)=size(a.u)
 ##################################################################

--- a/test/test_linsolve.jl
+++ b/test/test_linsolve.jl
@@ -61,85 +61,58 @@ end
 
 checklum(n, T) = checklum0(Val{n}, T)
 
-@static if VERSION >= v"1.9-rc0"
-    function checklurm0(::Type{Val{N}}, ::Type{T}) where {N, T}
-        A = MMatrix{N, N, Float64}(undef)
-        x = MVector{N, Float64}(undef)
-        b = MVector{N, Float64}(undef)
-        ipiv = MVector{N, Int64}(undef)
-        for i = 1:N
-            for j = 1:N
-                A[i, j] = -rand()
+
+function checklurx0(::Type{Val{N}}, ::Type{T}) where {N, T}
+    A = StrideArray{T}(undef, StaticInt(N), StaticInt(N))
+    x = StrideArray{T}(undef, StaticInt(N))
+    b = StrideArray{T}(undef, StaticInt(N))
+    ipiv = StrideArray{Int64}(undef, StaticInt(N))
+    for i = 1:N
+        for j = 1:N
+            A[i, j] = -rand()
             end
-            A[i, i] += 100
-            x[i] = 1
-        end
-        @gc_preserve mul!(b, A, x)
-        @gc_preserve inplace_linsolve!(A, b, ipiv)
-
+        A[i, i] += 100
+        x[i] = 1
+    end
+    @gc_preserve mul!(b, A, x)
+    @gc_preserve inplace_linsolve!(A, b, ipiv)
+    
         nm = 0
-        for i = 1:N
-            nm += (b[i] - x[i])^2
-        end
-
-        @assert sqrt(nm) / N < 100.0 * eps(Float64)
-        nothing
+    for i = 1:N
+        nm += (b[i] - x[i])^2
     end
 
-    checklurm(n, T) = checklurm0(Val{n}, T)
-
-    function checklurx0(::Type{Val{N}}, ::Type{T}) where {N, T}
-        A = StrideArray{T}(undef, StaticInt(N), StaticInt(N))
-        x = StrideArray{T}(undef, StaticInt(N))
-        b = StrideArray{T}(undef, StaticInt(N))
-        ipiv = StrideArray{Int64}(undef, StaticInt(N))
-        for i = 1:N
-            for j = 1:N
-                A[i, j] = -rand()
-            end
-            A[i, i] += 100
-            x[i] = 1
-        end
-        @gc_preserve mul!(b, A, x)
-        @gc_preserve inplace_linsolve!(A, b, ipiv)
-
-        nm = 0
-        for i = 1:N
-            nm += (b[i] - x[i])^2
-        end
-
-        @assert sqrt(nm) / N < 100.0 * eps(Float64)
-        nothing
-    end
-
-    checklurx(n, T) = checklurx0(Val{n}, T)
-
-    function checklurm0(::Type{Val{N}}, ::Type{T}) where {N, T}
-        A = MMatrix{N, N, Float64}(undef)
-        x = MVector{N, Float64}(undef)
-        b = MVector{N, Float64}(undef)
-        ipiv = MVector{N, Int64}(undef)
-        for i = 1:N
-            for j = 1:N
-                A[i, j] = -rand()
-            end
-            A[i, i] += 100
-            x[i] = 1
-        end
-        @gc_preserve mul!(b, A, x)
-        @gc_preserve inplace_linsolve!(A, b, ipiv)
-
-        nm = 0
-        for i = 1:N
-            nm += (b[i] - x[i])^2
-        end
-
-        @assert sqrt(nm) / N < 100.0 * eps(Float64)
-        nothing
-    end
-
-    checklurm(n, T) = checklurm0(Val{n}, T)
+    @assert sqrt(nm) / N < 100.0 * eps(Float64)
+    nothing
 end
+
+checklurx(n, T) = checklurx0(Val{n}, T)
+
+function checklurm0(::Type{Val{N}}, ::Type{T}) where {N, T}
+    A = MMatrix{N, N, Float64}(undef)
+    x = MVector{N, Float64}(undef)
+    b = MVector{N, Float64}(undef)
+    ipiv = MVector{N, Int64}(undef)
+    for i = 1:N
+        for j = 1:N
+            A[i, j] = -rand()
+        end
+        A[i, i] += 100
+        x[i] = 1
+    end
+    @gc_preserve mul!(b, A, x)
+    @gc_preserve inplace_linsolve!(A, b, ipiv)
+    
+    nm = 0
+    for i = 1:N
+        nm += (b[i] - x[i])^2
+    end
+    
+    @assert sqrt(nm) / N < 100.0 * eps(Float64)
+    nothing
+end
+
+checklurm(n, T) = checklurm0(Val{n}, T)
 
 function runtests()
     checklum(10, Float64)

--- a/test/test_state.jl
+++ b/test/test_state.jl
@@ -1,0 +1,49 @@
+module test_state
+using VoronoiFVM
+using VoronoiFVM: SystemState
+using ExtendableGrids
+using LinearAlgebra
+using Test
+
+flux(y,u,edge, data)= y[1]=u[1,1]-u[1,2]
+
+function bcondition(y,u,bnode,data)
+    boundary_robin!(y,u,bnode,region=1, value=0.0, factor=0.1)
+    boundary_robin!(y,u,bnode,region=2, value=1.0, factor=0.1)
+end
+
+function main(; unknown_storage=:dense)
+    g=simplexgrid(0:0.1:1)
+    sys=VoronoiFVM.System(g; flux, bcondition, species=[1], unknown_storage)
+    sol1=solve(sys)
+
+    state=VoronoiFVM.SystemState(sys)
+    sol2=solve!(state)
+    @test sol1≈sol2
+
+    control=SolverControl()
+    fixed_timesteps!(control,0.025)
+
+
+    tsol1=solve(sys; inival=0.0, times=(0,0.1), control)
+    tsol2=solve(sys; inival=tsol1.u[end], times=(0.1,0.2), control)
+    tsol3=solve(sys; inival=0.0, times=[0.0,0.1,0.2], control)
+    @test tsol3[end]≈tsol2[end]
+
+    xsol1=solve!(state; inival=0.0, times=(0,0.1), control)
+    xsol2=solve!(state; inival=tsol1.u[end], times=(0.1,0.2), control)
+    xsol3=solve!(state; inival=0.0, times=[0.0,0.1,0.2], control)
+    @test xsol3[end]≈xsol2[end]
+    @test xsol3[end]≈tsol3[end]
+
+
+
+end
+
+function runtests()
+    main(;unknown_storage=:dense)
+    main(;unknown_storage=:sparse)
+    
+end
+end
+

--- a/test/test_state.jl
+++ b/test/test_state.jl
@@ -17,6 +17,7 @@ function main(; unknown_storage=:dense)
     sys=VoronoiFVM.System(g; flux, bcondition, species=[1], unknown_storage)
     sol1=solve(sys)
 
+    # Solution and solution with state shall be the same
     state=VoronoiFVM.SystemState(sys)
     sol2=solve!(state)
     @test sol1≈sol2
@@ -25,16 +26,18 @@ function main(; unknown_storage=:dense)
     fixed_timesteps!(control,0.025)
 
 
+    # Allow initial values as result of previous time evolution
     tsol1=solve(sys; inival=0.0, times=(0,0.1), control)
     tsol2=solve(sys; inival=tsol1.u[end], times=(0.1,0.2), control)
     tsol3=solve(sys; inival=0.0, times=[0.0,0.1,0.2], control)
-    @test tsol3[end]≈tsol2[end]
+    @test tsol3.u[end]≈tsol2.u[end]
 
+    # Solution and solution with state shall be the same
     xsol1=solve!(state; inival=0.0, times=(0,0.1), control)
     xsol2=solve!(state; inival=tsol1.u[end], times=(0.1,0.2), control)
     xsol3=solve!(state; inival=0.0, times=[0.0,0.1,0.2], control)
-    @test xsol3[end]≈xsol2[end]
-    @test xsol3[end]≈tsol3[end]
+    @test xsol3.u[end]≈xsol2.u[end]
+    @test xsol3.u[end]≈tsol3.u[end]
 
 
 


### PR DESCRIPTION
Bug fixes. 
It was not possible to use the last timestep result as initial value for next solve in case of sparse unknown storage.