### PR TITLE
[CI] DownstreamTester fix name of PAT

### DIFF
--- a/.github/workflows/downstreamtester.yml
+++ b/.github/workflows/downstreamtester.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      ISSUETOKEN: ${{secrets.ISSUE_TOKEN}}
+      ISSUETOKEN: ${{secrets.ISSUETOKEN}}
 
     steps:
       # Check out master branch (to get the config file)


### PR DESCRIPTION
The names of the org secret and variable name in the workflow file don't match.
Since secrets themself cannot be renamed this renames the variable name in the workflow file instead.