### PR TITLE
[DownstreamTester] Add PrecompileTools bugfix branch until next release

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 ignore-words-list = missings,rcall,linke,strat,nd
-skip = CITATIONS.bib
+skip = CITATIONS.bib,.github/workflows/downstreamtester.yml

--- a/.github/workflows/downstreamtester.yml
+++ b/.github/workflows/downstreamtester.yml
@@ -46,6 +46,10 @@ jobs:
         run: |
           julia -e '
             using Pkg
+            try 
+              Pkg.add(url="https://github.com/jpthiele/PrecompileTools.jl", rev="teh/toplevel")
+            catch
+            end
             Pkg.add(name="DownstreamTester",version="0.1")
             using DownstreamTester
             DownstreamTester.nightly(;nightlylabels=["julia nightly"])'


### PR DESCRIPTION
This is a quick and somewhat dirty solution to get DownstreamTester working again.
A working bugfix PR is already open. 
I cloned the PR branch into my fork of PrecompileTools and add it in a try catch block.

There might also be a cleaner bugfix by changing the precompilation scripts in HTTP, 
but I don't know if anyone is working on that.

If the upstream bug is fixed either in HTTP.jl or PrecompileTools.jl I will remove the try catch block from the workflow again.