### PR TITLE
Allow for `generic_operator(f,u,sys,data)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
   - Try to remove type piracies
   - Remove `params` from edge, node structs (apparently never used)
 
+## v2.14 November 17, 2025
+  - Allow for `generic_operator(f,u,sys, data)`
+     - This allows to pass system state data in a proper way
+     - Deprecated `generic_operator(f,u,sys)`
+     
 ## v2.13 October 29, 2025
   - Restructure boundary flux calculation via test functions
     - Provide methods `integrate_TxFunc`, `integrate_TxSrc`, `integrate_∇TxFlux`, `integrate_TxEdgefunc` which allow

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VoronoiFVM"
 uuid = "82b139dc-5afc-11e9-35da-9b9bdfd336f3"
 authors = ["Jürgen Fuhrmann <juergen.fuhrmann@wias-berlin.de>", "Patrick Jaap", "Daniel Runge", "Dilara Abdel", "Jan Weidner", "Alexander Seiler", "Patricio Farrell", "Matthias Liero"]
-version = "2.13"
+version = "2.14"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/examples/Example405_GenericOperator.jl
+++ b/examples/Example405_GenericOperator.jl
@@ -30,7 +30,7 @@ function main(; n = 10, Plotter = nothing, verbose = false, unknown_storage = :s
     ## Here, instead of the flux function we provide a "generic operator"
     ## which provides the stiffness part of the problem. Its sparsity is detected automatically
     ## using Symbolics.jl
-    function generic_operator!(f, u, sys)
+    function generic_operator!(f, u, sys, data)
         f .= 0.0
         for i in 1:(length(X) - 1)
             du = D * (u[idx[1, i]] - u[idx[1, i + 1]]) / (X[i + 1] - X[i]) +

--- a/examples/Example406_WeirdReaction.jl
+++ b/examples/Example406_WeirdReaction.jl
@@ -142,7 +142,7 @@ function main(;
     ## Its sparsity is detected automatically using SparsityDetection.jl
     ## Here, we calculate the gradient of u_A at the boundary and store the value in u_C which
     ## is then used as a parameter in the boundary reaction
-    function generic_operator!(f, u, sys)
+    function generic_operator!(f, u, sys, data)
         f .= 0
         idx = unknown_indices(unknowns(sys))
         f[idx[problem_data.iC, 1]] = u[idx[problem_data.iC, 1]] +

--- a/src/vfvm_system.jl
+++ b/src/vfvm_system.jl
@@ -575,8 +575,8 @@ function _complete!(system::AbstractSystem{Tv, Tc, Ti, Tm}) where {Tv, Tc, Ti, T
             end
             tdetect = @elapsed begin
                 system.generic_matrix_prep = prepare_jacobian(
-                    applicable(system.physics.generic_operator, output, input, system, data) ?
-                        (f, u) -> system.physics.generic_operator(f, u, system, data) :
+                    applicable(system.physics.generic_operator, output, input, system, system.physics.data) ?
+                        (f, u) -> system.physics.generic_operator(f, u, system, system.physics.data) :
                         (f, u) -> system.physics.generic_operator(f, u, system),
                     output,
                     system.generic_matrix_backend,


### PR DESCRIPTION
This was an inconsistency in the API. 
Old way still works with deprecation warning.
