### PR TITLE
Make solver warning more detailed

### DIFF
--- a/src/vfvm_solver.jl
+++ b/src/vfvm_solver.jl
@@ -365,7 +365,7 @@ function solve_transient!(
                         istep
                     )
                 catch err
-                    err = "Problem at $(λstr)=$(λ |> rd), Δ$(λstr)=$(Δλ |> rd):\n$(err)"
+                    err = "Solver problem at $(λstr)=$(λ |> rd), Δ$(λstr)=$(Δλ |> rd):\n$(err) \nRetrying with smaller step size."
                     if (control.handle_exceptions)
                         _warn(err, stacktrace(catch_backtrace()))
                     else


### PR DESCRIPTION
I have made the warning more detailed within the automatic time/embedding step routine. It now explicitly states that the solver retries with a smaller step size.

FYI: @pjaap, @PatricioFarrell 
