### PR TITLE
Add detailed linear solver timings to NewtonSolverHistory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changes
+
+## v3.2.0 April 21, 2026
+  - Add detailed timing breakdown for linear solver in `NewtonSolverHistory`
+    - new `tlinsolve_asm` (assembly time, incl. preconditioner setup)
+    - new `tlinsolve_solve` (solve time)
+
 ## v3.1.0 February 17, 2026
   - Better control of factorizations during evolution
     - new `solvercontrol.factorize_every_timestep`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changes
 
-## v3.2.0 April 21, 2026
+## v3.2.0 April 27, 2026
   - Add detailed timing breakdown for linear solver in `NewtonSolverHistory`
-    - new `tlinsolve_asm` (assembly time, incl. preconditioner setup)
+    - new `tlinsolve_setup` (assembly time, incl. preconditioner setup)
     - new `tlinsolve_solve` (solve time)
 
 ## v3.1.0 February 17, 2026

--- a/examples/DevEx003_Solvers.jl
+++ b/examples/DevEx003_Solvers.jl
@@ -19,17 +19,15 @@ using AMGCLWrap
 using AlgebraicMultigrid
 using LinearAlgebra
 
-
 using Test
 
 
-function main(; n = 10, Plotter = nothing, assembly = :edgwwise, kwargs...)
+function main(; n = 10, Plotter = nothing, assembly = :edgewise, kwargs...)
     h = 1.0 / convert(Float64, n)
     X = collect(0.0:h:1.0)
     Y = collect(0.0:h:1.0)
 
     grid = simplexgrid(X, Y)
-    nn = num_nodes(grid)
 
     eps = 1.0e-2
 

--- a/examples/DevEx006_NewtonSolverHistory.jl
+++ b/examples/DevEx006_NewtonSolverHistory.jl
@@ -1,0 +1,97 @@
+#=
+
+# 006: Newton Solver History
+([source code](@__SOURCE_URL__))
+
+This example demonstrates how to inspect the linear solver timing
+information stored in the Newton solver history.
+
+=#
+
+module DevEx006_NewtonSolverHistory
+
+using VoronoiFVM
+using ExtendableGrids
+using LinearSolve
+using ExtendableSparse: ILUZeroPreconBuilder
+
+using Test
+
+
+function main(; n = 10, assembly = :edgewise, kwargs...)
+    h = 1.0 / convert(Float64, n)
+    X = collect(0.0:h:1.0)
+    Y = collect(0.0:h:1.0)
+
+    grid = simplexgrid(X, Y)
+
+    eps = 1.0e-2
+
+    function reaction(f, u, node, data)
+        f[1] = u[1]^2
+        return nothing
+    end
+
+    function flux(f, u, edge, data)
+        f[1] = eps * (u[1, 1]^2 - u[1, 2]^2)
+        return nothing
+    end
+
+    function source(f, node, data)
+        x1 = node[1] - 0.5
+        x2 = node[2] - 0.5
+        f[1] = exp(-20.0 * (x1^2 + x2^2))
+        return nothing
+    end
+
+    function bcondition(f, u, node, data)
+        boundary_dirichlet!(f, u, node; species = 1, region = 2, value = 1.0)
+        boundary_dirichlet!(f, u, node; species = 1, region = 4, value = 1.0)
+        return nothing
+    end
+
+    sys = VoronoiFVM.System(
+        grid; reaction, flux, source, bcondition, assembly,
+        species = [1]
+    )
+
+    @info "UMFPACK:"
+    sol = solve(
+        sys;
+        inival = 0.5,
+        method_linear = LinearSolve.UMFPACKFactorization(),
+        kwargs...
+    )
+    sol_history = history(sol)
+    tlinsolve = sol_history.tlinsolve
+    tlinsolve_setup = sol_history.tlinsolve_setup
+    tlinsolve_solve = sol_history.tlinsolve_solve
+    @test tlinsolve ≈ tlinsolve_setup + tlinsolve_solve
+
+    @info "Krylov-ilu0:"
+    sol = solve(
+        sys;
+        inival = 0.5,
+        method_linear = KrylovJL_BICGSTAB(precs = ILUZeroPreconBuilder()),
+        kwargs...
+    )
+    sol_history = history(sol)
+    tlinsolve = sol_history.tlinsolve
+    tlinsolve_setup = sol_history.tlinsolve_setup
+    tlinsolve_solve = sol_history.tlinsolve_solve
+    @test tlinsolve ≈ tlinsolve_setup + tlinsolve_solve
+
+    return @test tlinsolve ≈ tlinsolve_setup + tlinsolve_solve
+end
+
+function runtests()
+    @testset "edgewise" begin
+        main(; assembly = :edgewise)
+    end
+    @testset "cellwise" begin
+        main(; assembly = :cellwise)
+    end
+    return nothing
+end
+
+end

--- a/examples/DevEx006_NewtonSolverHistory.jl
+++ b/examples/DevEx006_NewtonSolverHistory.jl
@@ -60,28 +60,30 @@ function main(; n = 10, assembly = :edgewise, kwargs...)
         sys;
         inival = 0.5,
         method_linear = LinearSolve.UMFPACKFactorization(),
+        log = true,
         kwargs...
     )
     sol_history = history(sol)
     tlinsolve = sol_history.tlinsolve
     tlinsolve_setup = sol_history.tlinsolve_setup
     tlinsolve_solve = sol_history.tlinsolve_solve
-    @test tlinsolve ≈ tlinsolve_setup + tlinsolve_solve
+    @test tlinsolve ≈ tlinsolve_setup + tlinsolve_solve atol = 0.1
 
     @info "Krylov-ilu0:"
     sol = solve(
         sys;
         inival = 0.5,
         method_linear = KrylovJL_BICGSTAB(precs = ILUZeroPreconBuilder()),
+        log = true,
         kwargs...
     )
     sol_history = history(sol)
     tlinsolve = sol_history.tlinsolve
     tlinsolve_setup = sol_history.tlinsolve_setup
     tlinsolve_solve = sol_history.tlinsolve_solve
-    @test tlinsolve ≈ tlinsolve_setup + tlinsolve_solve
+    @test tlinsolve ≈ tlinsolve_setup + tlinsolve_solve atol = 0.1
 
-    return @test tlinsolve ≈ tlinsolve_setup + tlinsolve_solve
+    return @test tlinsolve ≈ tlinsolve_setup + tlinsolve_solve atol = 0.1
 end
 
 function runtests()

--- a/examples/DevEx006_NewtonSolverHistory.jl
+++ b/examples/DevEx006_NewtonSolverHistory.jl
@@ -67,7 +67,7 @@ function main(; n = 10, assembly = :edgewise, kwargs...)
     tlinsolve = sol_history.tlinsolve
     tlinsolve_setup = sol_history.tlinsolve_setup
     tlinsolve_solve = sol_history.tlinsolve_solve
-    @test tlinsolve ≈ tlinsolve_setup + tlinsolve_solve atol = 0.1
+    @test tlinsolve ≥ tlinsolve_setup + tlinsolve_solve
 
     @info "Krylov-ilu0:"
     sol = solve(
@@ -81,9 +81,9 @@ function main(; n = 10, assembly = :edgewise, kwargs...)
     tlinsolve = sol_history.tlinsolve
     tlinsolve_setup = sol_history.tlinsolve_setup
     tlinsolve_solve = sol_history.tlinsolve_solve
-    @test tlinsolve ≈ tlinsolve_setup + tlinsolve_solve atol = 0.1
+    @test tlinsolve ≥ tlinsolve_setup + tlinsolve_solve
 
-    return @test tlinsolve ≈ tlinsolve_setup + tlinsolve_solve atol = 0.1
+    return @test tlinsolve ≥ tlinsolve_setup + tlinsolve_solve
 end
 
 function runtests()

--- a/src/vfvm_history.jl
+++ b/src/vfvm_history.jl
@@ -20,13 +20,13 @@ Base.@kwdef mutable struct NewtonSolverHistory <: AbstractVector{Float64}
     """ Elapsed time for assembly """
     tasm::Float64 = 0.0
 
-    """ Elapsed time for linear solve: total """
+    """ Elapsed time for linear solver: total """
     tlinsolve::Float64 = 0.0
 
-    """ Elapsed time for linear solve: assembly step """
-    tlinsolve_asm::Float64 = 0.0
+    """ Elapsed time for linear solver: setup phase (assembly, preconditioner setup) """
+    tlinsolve_setup::Float64 = 0.0
 
-    """ Elapsed time for linear solve: solve step """
+    """ Elapsed time for linear solver: solve phase """
     tlinsolve_solve::Float64 = 0.0
 
     """ History of norms of ``||u_{i+1}-u_i||``"""

--- a/src/vfvm_history.jl
+++ b/src/vfvm_history.jl
@@ -21,7 +21,7 @@ Base.@kwdef mutable struct NewtonSolverHistory <: AbstractVector{Float64}
     tasm::Float64 = 0.0
 
     """ Elapsed time for linear solve: total """
-    tlinsolve_total::Float64 = 0.0
+    tlinsolve::Float64 = 0.0
 
     """ Elapsed time for linear solve: assembly step """
     tlinsolve_asm::Float64 = 0.0

--- a/src/vfvm_history.jl
+++ b/src/vfvm_history.jl
@@ -20,8 +20,14 @@ Base.@kwdef mutable struct NewtonSolverHistory <: AbstractVector{Float64}
     """ Elapsed time for assembly """
     tasm::Float64 = 0.0
 
-    """ Elapsed time for linear solve """
-    tlinsolve::Float64 = 0.0
+    """ Elapsed time for linear solve: total """
+    tlinsolve_total::Float64 = 0.0
+
+    """ Elapsed time for linear solve: assembly step """
+    tlinsolve_asm::Float64 = 0.0
+
+    """ Elapsed time for linear solve: solve step """
+    tlinsolve_solve::Float64 = 0.0
 
     """ History of norms of ``||u_{i+1}-u_i||``"""
     updatenorm = zeros(0)

--- a/src/vfvm_linsolve.jl
+++ b/src/vfvm_linsolve.jl
@@ -4,8 +4,8 @@ canonical_matrix(A) = A
 canonical_matrix(A::AbstractExtendableSparseMatrixCSC) = SparseMatrixCSC(A)
 
 function _solve_linear!(u, state, nlhistory, control, method_linear, A, b, reuse_precs)
-    tasm_1 = 0.0
-    tasm_2 = 0.0
+    tsetup_1 = 0.0
+    tsetup_2 = 0.0
     tsolve = 0.0
 
     if isnothing(state.linear_cache)
@@ -15,7 +15,7 @@ function _solve_linear!(u, state, nlhistory, control, method_linear, A, b, reuse
         Pl = nothing
         nlhistory.nlu += 1
         p = LinearProblem(canonical_matrix(A), b)
-        tasm_1 = @elapsed begin
+        tsetup_1 = @elapsed begin
             state.linear_cache = init(
                 p,
                 method_linear;
@@ -27,18 +27,18 @@ function _solve_linear!(u, state, nlhistory, control, method_linear, A, b, reuse
             )
         end
         if control.log
-            nlhistory.tlinsolve_asm += tasm_1
+            nlhistory.tlinsolve_setup += tsetup_1
         end
         if doprint(control, 'l')
             out = @sprintf("    [l]inear: factorize #%d\n", nlhistory.nlu)
             _info(out)
         end
     else
-        tasm_2 = @elapsed begin
+        tsetup_2 = @elapsed begin
             reinit!(state.linear_cache; A = canonical_matrix(A), b, reuse_precs)
         end
         if control.log
-            nlhistory.tlinsolve_asm += tasm_2
+            nlhistory.tlinsolve_setup += tsetup_2
         end
         if !reuse_precs
             nlhistory.nlu += 1

--- a/src/vfvm_linsolve.jl
+++ b/src/vfvm_linsolve.jl
@@ -4,6 +4,10 @@ canonical_matrix(A) = A
 canonical_matrix(A::AbstractExtendableSparseMatrixCSC) = SparseMatrixCSC(A)
 
 function _solve_linear!(u, state, nlhistory, control, method_linear, A, b, reuse_precs)
+    tasm_1 = 0.0
+    tasm_2 = 0.0
+    tsolve = 0.0
+
     if isnothing(state.linear_cache)
         if !isa(method_linear, LinearSolve.SciMLLinearSolveAlgorithm)
             @warn "use of $(typeof(method_linear)) is deprecated, use an algorithm from LinearSolve"
@@ -11,21 +15,31 @@ function _solve_linear!(u, state, nlhistory, control, method_linear, A, b, reuse
         Pl = nothing
         nlhistory.nlu += 1
         p = LinearProblem(canonical_matrix(A), b)
-        state.linear_cache = init(
-            p,
-            method_linear;
-            abstol = control.abstol_linear,
-            reltol = control.reltol_linear,
-            maxiters = control.maxiters_linear,
-            verbose = doprint(control, 'l'),
-            Pl,
-        )
+        tasm_1 = @elapsed begin
+            state.linear_cache = init(
+                p,
+                method_linear;
+                abstol = control.abstol_linear,
+                reltol = control.reltol_linear,
+                maxiters = control.maxiters_linear,
+                verbose = doprint(control, 'l'),
+                Pl,
+            )
+        end
+        if control.log
+            nlhistory.tlinsolve_asm += tasm_1
+        end
         if doprint(control, 'l')
             out = @sprintf("    [l]inear: factorize #%d\n", nlhistory.nlu)
             _info(out)
         end
     else
-        reinit!(state.linear_cache; A = canonical_matrix(A), b, reuse_precs)
+        tasm_2 = @elapsed begin
+            reinit!(state.linear_cache; A = canonical_matrix(A), b, reuse_precs)
+        end
+        if control.log
+            nlhistory.tlinsolve_asm += tasm_2
+        end
         if !reuse_precs
             nlhistory.nlu += 1
             if doprint(control, 'l')
@@ -36,10 +50,16 @@ function _solve_linear!(u, state, nlhistory, control, method_linear, A, b, reuse
     end
 
     try
-        sol = LinearSolve.solve!(state.linear_cache)
+        local sol
+        tsolve = @elapsed begin
+            sol = LinearSolve.solve!(state.linear_cache)
+        end
         u .= sol.u
         nliniter = sol.iters
         nlhistory.nlin = sol.iters
+        if control.log
+            nlhistory.tlinsolve_solve += tsolve
+        end
     catch err
         if (control.handle_exceptions)
             _warn(err, stacktrace(catch_backtrace()))

--- a/src/vfvm_linsolve.jl
+++ b/src/vfvm_linsolve.jl
@@ -4,18 +4,15 @@ canonical_matrix(A) = A
 canonical_matrix(A::AbstractExtendableSparseMatrixCSC) = SparseMatrixCSC(A)
 
 function _solve_linear!(u, state, nlhistory, control, method_linear, A, b, reuse_precs)
-    tsetup_1 = 0.0
-    tsetup_2 = 0.0
-    tsolve = 0.0
 
     if isnothing(state.linear_cache)
         if !isa(method_linear, LinearSolve.SciMLLinearSolveAlgorithm)
             @warn "use of $(typeof(method_linear)) is deprecated, use an algorithm from LinearSolve"
         end
-        Pl = nothing
         nlhistory.nlu += 1
-        p = LinearProblem(canonical_matrix(A), b)
-        tsetup_1 = @elapsed begin
+        nlhistory.tlinsolve_setup += @elapsed begin
+            Pl = nothing
+            p = LinearProblem(canonical_matrix(A), b)
             state.linear_cache = init(
                 p,
                 method_linear;
@@ -26,19 +23,13 @@ function _solve_linear!(u, state, nlhistory, control, method_linear, A, b, reuse
                 Pl,
             )
         end
-        if control.log
-            nlhistory.tlinsolve_setup += tsetup_1
-        end
         if doprint(control, 'l')
             out = @sprintf("    [l]inear: factorize #%d\n", nlhistory.nlu)
             _info(out)
         end
     else
-        tsetup_2 = @elapsed begin
+        nlhistory.tlinsolve_setup += @elapsed begin
             reinit!(state.linear_cache; A = canonical_matrix(A), b, reuse_precs)
-        end
-        if control.log
-            nlhistory.tlinsolve_setup += tsetup_2
         end
         if !reuse_precs
             nlhistory.nlu += 1
@@ -51,15 +42,11 @@ function _solve_linear!(u, state, nlhistory, control, method_linear, A, b, reuse
 
     try
         local sol
-        tsolve = @elapsed begin
+        nlhistory.tlinsolve_solve += @elapsed begin
             sol = LinearSolve.solve!(state.linear_cache)
         end
         u .= sol.u
-        nliniter = sol.iters
         nlhistory.nlin = sol.iters
-        if control.log
-            nlhistory.tlinsolve_solve += tsolve
-        end
     catch err
         if (control.handle_exceptions)
             _warn(err, stacktrace(catch_backtrace()))

--- a/src/vfvm_solver.jl
+++ b/src/vfvm_solver.jl
@@ -23,7 +23,7 @@ function solve_step!(
     )
     nlhistory = NewtonSolverHistory()
     tasm = 0.0
-    tlinsolve_total = 0.0
+    tlinsolve = 0.0
     t = @elapsed begin
         solution .= oldsol
         residual = state.residual
@@ -92,7 +92,7 @@ function solve_step!(
 
             reuse_precs = (!control.factorize_every_newtonstep && niter > 1) || (istep_factorize % control.factorize_every_timestep != 0)
 
-            tlinsolve_total += @elapsed _solve_linear!(
+            tlinsolve += @elapsed _solve_linear!(
                 dofs(update),
                 state,
                 nlhistory,
@@ -176,7 +176,7 @@ function solve_step!(
     end
     if control.log
         nlhistory.time = t
-        nlhistory.tlinsolve_total = tlinsolve_total
+        nlhistory.tlinsolve = tlinsolve
         nlhistory.tasm = tasm
     end
 
@@ -187,7 +187,7 @@ function solve_step!(
     end
 
     if doprint(control, 'n') && !state.system.is_linear
-        _info("  [n]ewton: $(round(t, sigdigits = 3)) seconds asm: $(round(100 * tasm / t, sigdigits = 3))%, linsolve: $(round(100 * tlinsolve_total / t, sigdigits = 3))%")
+        _info("  [n]ewton: $(round(t, sigdigits = 3)) seconds asm: $(round(100 * tasm / t, sigdigits = 3))%, linsolve: $(round(100 * tlinsolve / t, sigdigits = 3))%")
     end
 
     if doprint(control, 'l') && state.system.is_linear

--- a/src/vfvm_solver.jl
+++ b/src/vfvm_solver.jl
@@ -23,7 +23,7 @@ function solve_step!(
     )
     nlhistory = NewtonSolverHistory()
     tasm = 0.0
-    tlinsolve = 0.0
+    tlinsolve_total = 0.0
     t = @elapsed begin
         solution .= oldsol
         residual = state.residual
@@ -92,7 +92,7 @@ function solve_step!(
 
             reuse_precs = (!control.factorize_every_newtonstep && niter > 1) || (istep_factorize % control.factorize_every_timestep != 0)
 
-            tlinsolve += @elapsed _solve_linear!(
+            tlinsolve_total += @elapsed _solve_linear!(
                 dofs(update),
                 state,
                 nlhistory,
@@ -176,7 +176,7 @@ function solve_step!(
     end
     if control.log
         nlhistory.time = t
-        nlhistory.tlinsolve = tlinsolve
+        nlhistory.tlinsolve_total = tlinsolve_total
         nlhistory.tasm = tasm
     end
 
@@ -187,7 +187,7 @@ function solve_step!(
     end
 
     if doprint(control, 'n') && !state.system.is_linear
-        _info("  [n]ewton: $(round(t, sigdigits = 3)) seconds asm: $(round(100 * tasm / t, sigdigits = 3))%, linsolve: $(round(100 * tlinsolve / t, sigdigits = 3))%")
+        _info("  [n]ewton: $(round(t, sigdigits = 3)) seconds asm: $(round(100 * tasm / t, sigdigits = 3))%, linsolve: $(round(100 * tlinsolve_total / t, sigdigits = 3))%")
     end
 
     if doprint(control, 'l') && state.system.is_linear


### PR DESCRIPTION
This PR extends `NewtonSolverHistory` by adding a more detailed timing breakdown for the linear solver.

Previously, only the total time spent (now renamed to `tlinsolve_total`) in the linear solve was tracked. This change introduces two additional fields:

`tlinsolve_asm`: time spent in assembling the linear system (including preconditioner setup)
`tlinsolve_solve`: time spent in the actual solve step

This allows for a clearer distinction between assembly and solve phases, which is particularly useful when analyzing the performance of iterative solvers and preconditioners.

I would appreciate any feedback on the naming and am happy to adjust it. :)