### PR TITLE
disable persistent tasks for all architectures on Julia 1.12

### DIFF
--- a/test/alltests.jl
+++ b/test/alltests.jl
@@ -125,13 +125,10 @@ end
     @test ExplicitImports.check_no_self_qualified_accesses(VoronoiFVM) === nothing
 end
 
-
 @testset "Aqua" begin
     persistent_tasks = true
     if VERSION >= v"1.12.0" && VERSION < v"1.13.0-alpha1"
-        if Sys.iswindows() || Sys.isapple()
-            persistent_tasks = false
-        end
+        persistent_tasks = false
     end
     Aqua.test_all(VoronoiFVM; persistent_tasks)
 end


### PR DESCRIPTION
It already was disabled for mac+win.
